### PR TITLE
ci: publish liblibrediffusion binaries as release assets on tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,21 +158,36 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
+      - name: Checkout source (Python export toolchain)
+        uses: actions/checkout@v4
+
       - name: Download built libraries
         uses: actions/download-artifact@v4
         with:
           path: artifacts
 
-      - name: Zip per-platform bundles
+      - name: Assemble per-platform bundles
         run: |
           set -eux
-          mkdir -p dist
-          # The library sits at the zip root: score extracts a "support" package into
-          # {RootPath}/support/librediffusion/, so the lib lands directly there.
-          (cd artifacts/liblibrediffusion-linux-x86_64 \
-             && zip -9 "$GITHUB_WORKSPACE/dist/x86_64-unknown-linux-gnu.zip" liblibrediffusion.so)
-          (cd artifacts/librediffusion-windows-x86_64 \
-             && zip -9 "$GITHUB_WORKSPACE/dist/x86_64-pc-windows-msvc.zip" librediffusion.dll)
+          # Everything is laid out FLAT (no version-named top directory) so the "support"
+          # package always extracts to the same {RootPath}/support/librediffusion folder,
+          # regardless of release. Each bundle = the platform library + the (platform-
+          # independent) Python export toolchain needed to build engines with train-lora.py.
+          mkdir -p stage/linux stage/windows dist
+          stage_toolchain() {
+            local dest="$1"
+            for p in train-lora.py pyproject.toml uv.lock README.md LICENSE \
+                     src klein img2img_turbo tools; do
+              [ -e "$p" ] && cp -r "$p" "$dest"/
+            done
+          }
+          stage_toolchain stage/linux
+          stage_toolchain stage/windows
+          cp artifacts/liblibrediffusion-linux-x86_64/liblibrediffusion.so stage/linux/
+          cp artifacts/librediffusion-windows-x86_64/librediffusion.dll    stage/windows/
+          # Zip the directory CONTENTS so the library + toolchain sit at the zip root.
+          (cd stage/linux   && zip -9 -r "$GITHUB_WORKSPACE/dist/x86_64-unknown-linux-gnu.zip" .)
+          (cd stage/windows && zip -9 -r "$GITHUB_WORKSPACE/dist/x86_64-pc-windows-msvc.zip" .)
           ls -la dist
 
       - name: Attach to release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ name: CI
 on:
   push:
     branches: [ master, main, sdxl-prebuilt-timestep ]
+    tags: [ 'v*' ]
   pull_request:
   workflow_dispatch:
 
@@ -84,7 +85,15 @@ jobs:
           source /opt/rh/gcc-toolset-13/enable
           export PATH=/usr/local/cuda/bin:$PATH
           cmake --build build --target librediffusion -j"$(nproc)"
+          strip --strip-unneeded build/liblibrediffusion.so || true
           ls -la build/liblibrediffusion.so
+
+      - name: Upload library
+        uses: actions/upload-artifact@v4
+        with:
+          name: liblibrediffusion-linux-x86_64
+          path: build/liblibrediffusion.so
+          if-no-files-found: error
 
   windows:
     name: Windows (latest CUDA)
@@ -132,4 +141,45 @@ jobs:
 
       - name: Build (all CUDA arches)
         shell: pwsh
-        run: cmake --build build --config Release --target librediffusion -j
+        run: |
+          cmake --build build --config Release --target librediffusion -j
+          Get-ChildItem build\librediffusion.dll
+
+      - name: Upload library
+        uses: actions/upload-artifact@v4
+        with:
+          name: librediffusion-windows-x86_64
+          path: build/librediffusion.dll
+          if-no-files-found: error
+
+  release:
+    name: Release (attach binaries on tag)
+    needs: [ linux, windows ]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Download built libraries
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Zip per-platform bundles
+        run: |
+          set -eux
+          mkdir -p dist
+          # The library sits at the zip root: score extracts a "support" package into
+          # {RootPath}/support/librediffusion/, so the lib lands directly there.
+          (cd artifacts/liblibrediffusion-linux-x86_64 \
+             && zip -9 "$GITHUB_WORKSPACE/dist/x86_64-unknown-linux-gnu.zip" liblibrediffusion.so)
+          (cd artifacts/librediffusion-windows-x86_64 \
+             && zip -9 "$GITHUB_WORKSPACE/dist/x86_64-pc-windows-msvc.zip" librediffusion.dll)
+          ls -la dist
+
+      - name: Attach to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: dist/*.zip
+          tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true


### PR DESCRIPTION
The CI built the library as a compile-check only. This uploads it as an artifact on every run, and on a `v*` tag adds a `release` job that zips each platform's library (at the zip root) and attaches it to the GitHub release under the asset names the ossia score-packages manifest expects:

- `liblibrediffusion.so` → `x86_64-unknown-linux-gnu.zip`
- `librediffusion.dll`   → `x86_64-pc-windows-msvc.zip`

The lib is at the zip root so score extracts a `support`-kind package straight into `{RootPath}/support/librediffusion/`. Lib is `strip`ped on Linux. No GPU needed (all CUDA arches emitted offline), same as the existing build jobs.

To cut a release: push a `v*` tag → both build jobs run → `release` attaches the two zips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)