### PR TITLE
fix(cuda-graph): keep graph-read conditioning/scheduler buffers at a stable address

### DIFF
--- a/src/librediffusion.cpp
+++ b/src/librediffusion.cpp
@@ -101,12 +101,22 @@ void LibreDiffusionPipeline::prepare_scheduler(
   c_skip_host_.assign(c_skip.begin(), c_skip.end());
   c_out_host_.assign(c_out.begin(), c_out.end());
 
-  // Allocate and copy scheduler parameters
-  alpha_prod_t_sqrt_ = std::make_unique<CUDATensor<float>>(config_.denoising_steps);
-  beta_prod_t_sqrt_ = std::make_unique<CUDATensor<float>>(config_.denoising_steps);
-  c_skip_ = std::make_unique<CUDATensor<float>>(config_.denoising_steps);
-  c_out_ = std::make_unique<CUDATensor<float>>(config_.denoising_steps);
-  sub_timesteps_ = std::make_unique<CUDATensor<float>>(config_.denoising_steps);
+  // Allocate and copy scheduler parameters. Grow-only / in-place: the captured 1-step CUDA graph reads
+  // sub_timesteps_ (and the scheduler step reads the coeff buffers) BY ADDRESS, and capture_signature()
+  // does NOT hash them. A live timesteps edit calls this every change; reallocating would move the
+  // device address and the replayed graph would read a stale/freed buffer -> "any change randomly breaks"
+  // (random because cudaFree+cudaMalloc may reuse the address). Reuse when the step count is unchanged
+  // (no recapture) and only (re)allocate + invalidate the graph on a size change. See reuse_or_realloc
+  // in librediffusion.embeddings.cpp and the set_controlnet_cond fix.
+  const size_t nsteps = (size_t)config_.denoising_steps;
+  auto reuse = [&](std::unique_ptr<CUDATensor<float>>& b) {
+    if(!b || b->size() != nsteps) { b = std::make_unique<CUDATensor<float>>(nsteps); graph_ready_ = false; }
+  };
+  reuse(alpha_prod_t_sqrt_);
+  reuse(beta_prod_t_sqrt_);
+  reuse(c_skip_);
+  reuse(c_out_);
+  reuse(sub_timesteps_);
 
   // Copy scheduler parameters to device
 

--- a/src/librediffusion.embeddings.cpp
+++ b/src/librediffusion.embeddings.cpp
@@ -8,13 +8,31 @@
 namespace librediffusion
 {
 
+// Grow-only / in-place (re)allocation for a buffer the captured CUDA graph reads BY ADDRESS. A live
+// prompt/timestep edit calls these prepare_* every change; reallocating would move the device address
+// and the replayed 1-step graph (whose memcpy nodes baked the capture-time pointer) would read a
+// stale/freed buffer -> garbage on the next edit (this is the "any change randomly breaks" regression;
+// random because cudaFree+cudaMalloc may or may not return the same address). capture_signature() does
+// NOT hash these buffers, so reuse the buffer when the shape is unchanged (no recapture needed) and only
+// (re)allocate + invalidate the graph on a genuine size change. Mirrors the set_controlnet_cond /
+// set_ipadapter_tokens fix.
+template <typename T>
+static void reuse_or_realloc(
+    std::unique_ptr<CUDATensor<T>>& buf, size_t n, bool& graph_ready)
+{
+  if(!buf || buf->size() != n)
+  {
+    buf = std::make_unique<CUDATensor<T>>(n);
+    graph_ready = false;  // address moved -> any captured graph is stale
+  }
+}
+
 void LibreDiffusionPipeline::prepare_embeds(
     const __half* prompt_embeds, // [batch_size, seq_len, hidden_dim]
     int seq_len, int hidden_dim)
 {
-  // Allocate prompt embeddings
   int prompt_size = config_.batch_size * seq_len * hidden_dim;
-  prompt_embeds_ = std::make_unique<CUDATensor<__half>>(prompt_size);
+  reuse_or_realloc(prompt_embeds_, (size_t)prompt_size, graph_ready_);
   prompt_embeds_->load_d2d(prompt_embeds, prompt_size, stream_);
 }
 
@@ -22,11 +40,10 @@ void LibreDiffusionPipeline::prepare_negative_embeds(
     const __half* negative_embeds, // [1, seq_len, hidden_dim]
     int seq_len, int hidden_dim)
 {
-  // Allocate negative (unconditional) embeddings for CFG
   // Stored as single embedding [1, seq_len, hidden_dim], repeated as needed during inference
   int size = 1 * seq_len * hidden_dim;
   assert(size > 0);
-  negative_embeds_ = std::make_unique<CUDATensor<__half>>(size);
+  reuse_or_realloc(negative_embeds_, (size_t)size, graph_ready_);
   assert(negative_embeds_.get());
   negative_embeds_->load_d2d(negative_embeds, size, stream_);
 }
@@ -35,14 +52,14 @@ void LibreDiffusionPipeline::prepare_sdxl_conditioning(
     const __half* text_embeds,  // [batch_size, pooled_dim]
     const __half* time_ids)     // [batch_size, 6]
 {
-  // Allocate and copy text_embeds (pooled embeddings from second CLIP encoder)
+  // text_embeds (pooled embeddings from second CLIP encoder)
   int text_embeds_size = config_.batch_size * config_.pooled_embedding_dim;
-  text_embeds_ = std::make_unique<CUDATensor<__half>>(text_embeds_size);
+  reuse_or_realloc(text_embeds_, (size_t)text_embeds_size, graph_ready_);
   text_embeds_->load_d2d(text_embeds, text_embeds_size, stream_);
 
-  // Allocate and copy time_ids [height, width, crop_top, crop_left, target_height, target_width]
+  // time_ids [height, width, crop_top, crop_left, target_height, target_width]
   int time_ids_size = config_.batch_size * config_.time_ids_dim;
-  time_ids_ = std::make_unique<CUDATensor<__half>>(time_ids_size);
+  reuse_or_realloc(time_ids_, (size_t)time_ids_size, graph_ready_);
   time_ids_->load_d2d(time_ids, time_ids_size, stream_);
 }
 
@@ -84,10 +101,7 @@ void LibreDiffusionPipeline::blend_embeds(
   // Allocate or reuse prompt_embeds_ for the blended result
   // Result shape: [batch_size, seq_len, hidden_dim]
   int size = config_.batch_size * seq_len * hidden_dim;
-  if(!prompt_embeds_ || prompt_embeds_->size() != static_cast<size_t>(size))
-  {
-    prompt_embeds_ = std::make_unique<CUDATensor<__half>>(size);
-  }
+  reuse_or_realloc(prompt_embeds_, (size_t)size, graph_ready_);
 
   // Initialize accumulator to zero
   launch_zero_fill_fp16(prompt_embeds_->data(), size, stream_);

--- a/src/librediffusion.unet.cpp
+++ b/src/librediffusion.unet.cpp
@@ -1371,6 +1371,20 @@ uint64_t LibreDiffusionPipeline::capture_signature() const
   if(predict_x0_batch_unet_output) h = mix(h, ptr(predict_x0_batch_unet_output->data()));
   if(predict_x0_batch_model_pred) h = mix(h, ptr(predict_x0_batch_model_pred->data()));
   if(predict_x0_batch_denoised) h = mix(h, ptr(predict_x0_batch_denoised->data()));
+  // Conditioning + scheduler buffers the captured body memcpy's from BY ADDRESS (prompt/negative embeds,
+  // SDXL pooled text_embeds/time_ids, sub_timesteps + scheduler coeffs). The prepare_* now reuse these
+  // in place for a fixed shape (stable address -> no recapture on a live prompt/timestep edit), but a
+  // genuine shape change moves them -> a changed signature -> recapture, which is the correct response.
+  // Hashing them here is belt-and-suspenders against any path that reallocates without invalidating.
+  if(prompt_embeds_) h = mix(h, ptr(prompt_embeds_->data()));
+  if(negative_embeds_) h = mix(h, ptr(negative_embeds_->data()));
+  if(text_embeds_) h = mix(h, ptr(text_embeds_->data()));
+  if(time_ids_) h = mix(h, ptr(time_ids_->data()));
+  if(sub_timesteps_) h = mix(h, ptr(sub_timesteps_->data()));
+  if(alpha_prod_t_sqrt_) h = mix(h, ptr(alpha_prod_t_sqrt_->data()));
+  if(beta_prod_t_sqrt_) h = mix(h, ptr(beta_prod_t_sqrt_->data()));
+  if(c_skip_) h = mix(h, ptr(c_skip_->data()));
+  if(c_out_) h = mix(h, ptr(c_out_->data()));
   if(ip_ext_ehs_) h = mix(h, ptr(ip_ext_ehs_->data()));
   // IP token source buffers: the captured body memcpy's from these into ip_ext_ehs_, so a moved
   // address (set_ipadapter_tokens/_image reallocating) must force a recapture. Grow-only allocation


### PR DESCRIPTION
## Problem

Changing a parameter at runtime regressed: it works in the initial state but **any change randomly breaks the rendering**.

Root cause is a **CUDA-graph stale device pointer**. For graph-eligible workflows (`denoising_steps==1 && cfg-none && !V2V` — SD-Turbo, SDXS, SDXL-Turbo, 1-step Hyper/LCM) the first frame **captures** a graph of the denoise step. That graph's `cudaMemcpyAsync` nodes read several device buffers **by their capture-time address**:

- `prompt_embeds_`, `sub_timesteps_`, and for SDXL `text_embeds_` / `time_ids_` (plus the scheduler coeff buffers).

But `capture_signature()` did **not** hash any of them, and the setters `prepare_embeds` / `prepare_negative_embeds` / `prepare_sdxl_conditioning` / `prepare_scheduler` **unconditionally reallocated** them on every live change. So a runtime prompt/timestep edit freed and re-allocated the buffer to a (possibly) different address while the signature stayed the same → **no recapture** → the replayed graph copied from the **stale/freed address**.

It's *"random"* because `cudaFree`+`cudaMalloc` may or may not hand back the same address: sometimes the change is silently ignored, sometimes the reclaimed block yields garbage/black.

This is the **same bug class already fixed in-place** for `set_controlnet_cond` / `set_ipadapter_tokens` (whose comments already warn that "reallocating every frame moves the device address, which silently breaks CUDA-graph replay"). The `prepare_*` setters just never got the same treatment.

## Fix

- Make `prepare_embeds` / `prepare_negative_embeds` / `prepare_sdxl_conditioning` / `blend_embeds` (via a `reuse_or_realloc` helper) and `prepare_scheduler` **grow-only / in-place**: reuse the buffer when the element count is unchanged (no recapture on the common same-shape live edit), only (re)allocate + set `graph_ready_ = false` on a genuine size change.
- Hash those buffers in `capture_signature()` as defense-in-depth, so any address move from any path forces a recapture.

**Invariant going forward:** any device buffer the captured single-step body reads must be both (a) allocated grow-only/in-place by its setter and (b) hashed in `capture_signature()`.

## Verification

A capture-then-change A/B repro on the SDXS 1-step bundle (graph on): capture on prompt A → switch to B → switch back to A.

| | prompt B vs A | back to A | verdict |
|---|---|---|---|
| **before** | MAD **0.00** (change ignored) | 0.00 | **FAIL** 3/3 |
| **after** | MAD **87.5** (clean, distinct) | 0.00 (reproduces A) | **PASS** |

`.so` rebuilt (sm_89), no other paths affected (multi-step / cfg / V2V / non-graph configs never captured a graph and are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)