### PR TITLE
fix(img2img-turbo export): support sketch_to_image_stochastic + robust ONNX export

### DIFF
--- a/src/streamdiffusion/img2img_turbo/export.py
+++ b/src/streamdiffusion/img2img_turbo/export.py
@@ -98,8 +98,12 @@ class DecoderExport(torch.nn.Module):
 
 
 def _onnx_export(mod, args_tuple, names_in, names_out, path, dynamic=None):
+    # Force the legacy TorchScript exporter (dynamo=False): torch>=2.9 defaults torch.onnx.export to the
+    # dynamo/torch.export path, which is stricter and fails to trace some pix2pix-turbo UNets (e.g.
+    # sketch_to_image_stochastic -> "unsupported operand -: int and NoneType"). The TorchScript path
+    # handles them and is what the edge_to_image bundle was built with.
     torch.onnx.export(mod, args_tuple, path, input_names=names_in, output_names=names_out,
-                      dynamic_axes=dynamic, opset_version=17, do_constant_folding=True)
+                      dynamic_axes=dynamic, opset_version=17, do_constant_folding=True, dynamo=False)
     print(f"  wrote {path}")
 
 
@@ -182,5 +186,12 @@ def load_model(pretrained_name, pretrained_path, ckpt_folder):
                       ckpt_folder=ckpt_folder)
     m.set_eval()
     fuse_loras(m.unet, m.vae)
+    # Stochastic variants (e.g. sketch_to_image_stochastic) replace unet.conv_in with a TwinConv that
+    # blends a pretrained and a trained conv by a runtime ratio `r` (default None -> crashes export).
+    # Bake r=1.0: at r=1 the model collapses to the deterministic skip-VAE flow our pipeline implements
+    # (unet_input = encoded_control*r + noise_map*(1-r) = encoded_control; TwinConv -> the trained conv;
+    # LoRA already fused at 1.0; VAE skip gamma baked at 1.0). Harmless no-op for non-TwinConv models.
+    if hasattr(m.unet, "conv_in") and hasattr(m.unet.conv_in, "r"):
+        m.unet.conv_in.r = 1.0
     m.unet.eval(); m.vae.eval()
     return m


### PR DESCRIPTION
## Problem

`train-lora.py --type img2img-turbo --model sketch_to_image_stochastic` failed at ONNX export with `TypeError: unsupported operand type(s) for -: 'int' and 'NoneType'`. Only `edge_to_image` exported.

Root cause: the *stochastic* pix2pix-turbo variants replace `unet.conv_in` with a `TwinConv` that blends a pretrained and a trained conv by a runtime ratio `r` (`x1*(1-r) + x2*r`), defaulting to `r=None`. The export wraps the UNet directly (bypassing `Pix2Pix_Turbo.forward`, which is what normally sets `r`), so `r` stays `None` and the trace crashes.

## Fix (`img2img_turbo/export.py`)

1. **Bake `unet.conv_in.r = 1.0`** in `load_model` for TwinConv variants. At `r=1` the stochastic model collapses to exactly the deterministic skip-VAE flow this pipeline implements: `unet_input = encoded_control*r + noise_map*(1-r) = encoded_control`, `TwinConv -> the trained conv`, LoRA already fused at 1.0, VAE skip gamma baked at 1.0. So it drops into the existing static engines unchanged. Harmless no-op for non-TwinConv models (`edge_to_image`).
2. **Force the legacy TorchScript ONNX exporter (`dynamo=False`)**. torch>=2.9 defaults `torch.onnx.export` to the dynamo/`torch.export` path, which is too strict to trace these UNets; the TorchScript path handles them (and is what `edge_to_image` was effectively built with).

## Note

Build these at 512 (`--opt-width/height 512`); the 1024 default OOMs the 128²-latent self-attention at ~11 GB/tactic.

## Verification

Re-exported `sketch_to_image_stochastic` at 512 -> complete 4-engine bundle. Smoke-tested through the node's img2img-turbo C-API (`create -> clip_compute_embeddings -> frame_dev`): produces a clean sketch->image translation (verified visually). Both pix2pix-turbo variants (`edge_to_image` + `sketch_to_image_stochastic`) now export and run end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)