### PR TITLE
feat(lora): runtime-scalable LoRA via --lora PATH:runtime + a lora_scale engine input

### DIFF
--- a/src/librediffusion.cpp
+++ b/src/librediffusion.cpp
@@ -255,4 +255,27 @@ void LibreDiffusionPipeline::set_ipadapter_scale_vector(const float* per_layer, 
   ipadapter_scale_vec_.assign(per_layer, per_layer + num_ip_layers);
 }
 
+int LibreDiffusionPipeline::num_runtime_loras() const
+{
+  return unet_ ? unet_->numRuntimeLoras() : 0;
+}
+
+void LibreDiffusionPipeline::set_lora_scale(int idx, float scale)
+{
+  if(unet_)
+    unet_->setLoraScale(idx, scale);
+  // The captured 1-step CUDA graph bakes the lora_scale H2D (contents staged before enqueue). A value
+  // change must re-stage -> force a recapture (the buffer address is stable + hashed in capture_signature,
+  // so a no-op set leaves the graph intact). Same discipline as a prompt/scheduler change.
+  graph_ready_ = false;
+}
+
+void LibreDiffusionPipeline::set_lora_scale_vector(const float* scales, int n)
+{
+  if(unet_)
+    for(int i = 0; i < n; i++)
+      unet_->setLoraScale(i, scales[i]);
+  graph_ready_ = false;
+}
+
 }

--- a/src/librediffusion.hpp
+++ b/src/librediffusion.hpp
@@ -244,6 +244,12 @@ public:
   // Uniform scale across all IP layers; or a per-layer vector of length num_ip_layers.
   void set_ipadapter_scale(float scale);
   void set_ipadapter_scale_vector(const float* per_layer, int num_ip_layers);
+
+  // Runtime LoRA: number of lora_scale slots the loaded UNet engine declares (0 if none); set slot idx
+  // (0..N-1) or the whole vector. 1.0 = the LoRA fully on (== a baked engine); 0.0 = off.
+  int num_runtime_loras() const;
+  void set_lora_scale(int idx, float scale);
+  void set_lora_scale_vector(const float* scales, int n);
   // On-device path: take a raw host RGBA style image [img_h,img_w,4], run the CLIP image encoder +
   // projection engines, and set the pos tokens (+ neg tokens = projection of zeros). Requires the
   // image encoder engines to be configured (ipadapter_image_encoder_path / _proj_path). Call once /

--- a/src/librediffusion.unet.cpp
+++ b/src/librediffusion.unet.cpp
@@ -1385,6 +1385,9 @@ uint64_t LibreDiffusionPipeline::capture_signature() const
   if(beta_prod_t_sqrt_) h = mix(h, ptr(beta_prod_t_sqrt_->data()));
   if(c_skip_) h = mix(h, ptr(c_skip_->data()));
   if(c_out_) h = mix(h, ptr(c_out_->data()));
+  // Runtime-LoRA lora_scale buffer (the captured UNet enqueue reads it). Grow-only -> stable address;
+  // set_lora_scale forces a recapture on a VALUE change (the staged H2D contents are baked into the graph).
+  if(unet_ && unet_->loraScaleBufferAddr()) h = mix(h, ptr(unet_->loraScaleBufferAddr()));
   if(ip_ext_ehs_) h = mix(h, ptr(ip_ext_ehs_->data()));
   // IP token source buffers: the captured body memcpy's from these into ip_ext_ehs_, so a moved
   // address (set_ipadapter_tokens/_image reallocating) must force a recapture. Grow-only allocation

--- a/src/librediffusion_c.cpp
+++ b/src/librediffusion_c.cpp
@@ -879,6 +879,33 @@ librediffusion_set_ipadapter_scale_vector(
   });
 }
 
+LIBREDIFFUSION_API int LIBREDIFFUSION_CALL
+librediffusion_num_runtime_loras(librediffusion_pipeline_handle pipeline)
+{
+  if (!pipeline || !pipeline->cpp_pipeline)
+    return 0;
+  return pipeline->cpp_pipeline->num_runtime_loras();
+}
+
+LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
+librediffusion_set_lora_scale(librediffusion_pipeline_handle pipeline, int idx, float scale)
+{
+  if (!pipeline || !pipeline->cpp_pipeline)
+    return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
+  return try_catch_wrapper([&]() { pipeline->cpp_pipeline->set_lora_scale(idx, scale); });
+}
+
+LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
+librediffusion_set_lora_scale_vector(
+    librediffusion_pipeline_handle pipeline, const float* scales, int n)
+{
+  if (!pipeline || !pipeline->cpp_pipeline)
+    return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
+  if (!scales)
+    return LIBREDIFFUSION_ERROR_NULL_POINTER;
+  return try_catch_wrapper([&]() { pipeline->cpp_pipeline->set_lora_scale_vector(scales, n); });
+}
+
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_reseed(librediffusion_pipeline_handle pipeline, int64_t seed)
 {

--- a/src/librediffusion_c.h
+++ b/src/librediffusion_c.h
@@ -535,6 +535,19 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_set_ipadapter_scale_vector(
     librediffusion_pipeline_handle pipeline, const float* per_layer, int num_ip_layers);
 
+/** Runtime LoRA: number of lora_scale slots the loaded UNet engine declares (0 if none). Slot order =
+ *  the order of the PATH:runtime LoRAs at export time (also in bundle.json lora_runtime_slots). */
+LIBREDIFFUSION_API int LIBREDIFFUSION_CALL
+librediffusion_num_runtime_loras(librediffusion_pipeline_handle pipeline);
+
+/** Set the runtime scale of LoRA slot `idx` (0..N-1). 1.0 = fully on (== a baked engine), 0.0 = off. */
+LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
+librediffusion_set_lora_scale(librediffusion_pipeline_handle pipeline, int idx, float scale);
+
+/** Set all runtime LoRA scales at once (length n = num_runtime_loras). */
+LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
+librediffusion_set_lora_scale_vector(librediffusion_pipeline_handle pipeline, const float* scales, int n);
+
 /**
  * Reseed the random number generator.
  *

--- a/src/librediffusion_loader.hpp
+++ b/src/librediffusion_loader.hpp
@@ -113,6 +113,9 @@ public:
   LIBREDIFFUSION_SYMBOL_DEF(librediffusion, set_ipadapter_tokens);
   LIBREDIFFUSION_SYMBOL_DEF(librediffusion, set_ipadapter_scale);
   LIBREDIFFUSION_SYMBOL_DEF(librediffusion, set_ipadapter_scale_vector);
+  LIBREDIFFUSION_SYMBOL_DEF(librediffusion, num_runtime_loras);
+  LIBREDIFFUSION_SYMBOL_DEF(librediffusion, set_lora_scale);
+  LIBREDIFFUSION_SYMBOL_DEF(librediffusion, set_lora_scale_vector);
 
   /*=========================================================================*/
   /* High-Level Inference (CPU buffers)                                      */
@@ -394,6 +397,9 @@ private:
     LIBREDIFFUSION_SYMBOL_INIT_OPT(librediffusion, set_ipadapter_tokens);
     LIBREDIFFUSION_SYMBOL_INIT_OPT(librediffusion, set_ipadapter_scale);
     LIBREDIFFUSION_SYMBOL_INIT_OPT(librediffusion, set_ipadapter_scale_vector);
+    LIBREDIFFUSION_SYMBOL_INIT_OPT(librediffusion, num_runtime_loras);
+    LIBREDIFFUSION_SYMBOL_INIT_OPT(librediffusion, set_lora_scale);
+    LIBREDIFFUSION_SYMBOL_INIT_OPT(librediffusion, set_lora_scale_vector);
 
     /*=====================================================================*/
     /* High-Level Inference (CPU buffers)                                  */

--- a/src/streamdiffusion/acceleration/tensorrt/fp8_quantize.py
+++ b/src/streamdiffusion/acceleration/tensorrt/fp8_quantize.py
@@ -22,6 +22,7 @@ weight quantization relieves.
 from __future__ import annotations
 
 import copy
+import os
 import re
 
 import torch

--- a/src/tensorrt_wrappers.cpp
+++ b/src/tensorrt_wrappers.cpp
@@ -646,6 +646,8 @@ void UNetWrapper::forward_v2v(
   if(!context_->setTensorAddress("latent", output_buffer_->data()))
     throw std::runtime_error("forward_v2v: failed to set latent address");
 
+  bindLoraScale(stream);  // runtime-LoRA + V2V
+
   if(!context_->enqueueV3(stream))
     throw std::runtime_error("forward_v2v: failed to enqueue inference");
 
@@ -822,6 +824,8 @@ void UNetWrapper::forward_controlnet(
   if(!context_->setTensorAddress("latent", output_buffer_->data()))
     throw std::runtime_error("Failed to set latent tensor address");
 
+  bindLoraScale(stream);  // runtime-LoRA + ControlNet (SD1.5)
+
   if(!context_->enqueueV3(stream))
     throw std::runtime_error("Failed to enqueue inference (controlnet UNet)");
 
@@ -911,6 +915,8 @@ void UNetWrapper::forward_ipadapter(
     throw std::runtime_error("Failed to set ipadapter_scale tensor address");
   if(!context_->setTensorAddress("latent", output_buffer_->data()))
     throw std::runtime_error("Failed to set latent tensor address");
+
+  bindLoraScale(stream);  // runtime-LoRA + IP-Adapter (SD1.5)
 
   if(!context_->enqueueV3(stream))
     throw std::runtime_error("Failed to enqueue inference (IP-Adapter UNet)");
@@ -1022,6 +1028,8 @@ void UNetWrapper::forward_ipadapter_sdxl(
     throw std::runtime_error("Failed to set ipadapter_scale tensor address");
   if(!context_->setTensorAddress("latent", output_buffer_->data()))
     throw std::runtime_error("Failed to set latent tensor address");
+
+  bindLoraScale(stream);  // runtime-LoRA + IP-Adapter (SDXL)
 
   if(!context_->enqueueV3(stream))
     throw std::runtime_error("Failed to enqueue inference (SDXL IP-Adapter UNet)");
@@ -1145,6 +1153,8 @@ void UNetWrapper::forward_controlnet_sdxl(
     throw std::runtime_error("Failed to set time_ids tensor address");
   if(!context_->setTensorAddress("latent", output_buffer_->data()))
     throw std::runtime_error("Failed to set latent tensor address");
+
+  bindLoraScale(stream);  // runtime-LoRA + ControlNet (SDXL)
 
   if(!context_->enqueueV3(stream))
     throw std::runtime_error("Failed to enqueue inference (controlnet SDXL UNet)");

--- a/src/tensorrt_wrappers.cpp
+++ b/src/tensorrt_wrappers.cpp
@@ -81,6 +81,8 @@ UNetWrapper::~UNetWrapper()
   // Unique_ptrs will handle cleanup automatically
   if(ipadapter_scale_pinned_)
     cudaFreeHost(ipadapter_scale_pinned_);
+  if(lora_scale_pinned_)
+    cudaFreeHost(lora_scale_pinned_);
 }
 
 void UNetWrapper::loadEngine(const std::string& engine_path)
@@ -188,6 +190,25 @@ void UNetWrapper::loadEngine(const std::string& engine_path)
                   << (num_ip_layers_ ? std::to_string(num_ip_layers_) : std::string("dynamic"))
                   << " layers) for " << engine_path << std::endl;
       }
+      else if(nm == "lora_scale" && eng->getTensorIOMode(tn) == nvinfer1::TensorIOMode::kINPUT)
+      {
+        // Runtime LoRA: lora_scale[N] HALF vector (N = #runtime LoRAs). Static engine declares N>0;
+        // a dynamic build reads N from the profile MAX (mirrors ipadapter_scale).
+        has_lora_scale_ = true;
+        nvinfer1::Dims d = eng->getTensorShape(tn);
+        if(d.nbDims == 1 && d.d[0] > 0)
+          num_runtime_loras_ = (int)d.d[0];
+        else if(d.nbDims == 1)
+        {
+          nvinfer1::Dims dmax = eng->getProfileShape(tn, 0, nvinfer1::OptProfileSelector::kMAX);
+          if(dmax.nbDims == 1 && dmax.d[0] > 0)
+            num_runtime_loras_ = (int)dmax.d[0];
+        }
+        if(num_runtime_loras_ > 0)
+          lora_scale_host_.assign(num_runtime_loras_, 1.0f);  // default: every runtime LoRA fully on
+        std::cout << "Note: engine has runtime LoRA (lora_scale input, "
+                  << num_runtime_loras_ << " slot(s)) for " << engine_path << std::endl;
+      }
     }
 
     // Derive the per-residual ControlNet geometry from the engine's input_control_NN bindings, so the
@@ -286,6 +307,62 @@ bool UNetWrapper::needsReallocation(
          || shape_cache_.height != height || shape_cache_.width != width
          || shape_cache_.seq_len != seq_len || shape_cache_.hidden_dim != hidden_dim
          || shape_cache_.pooled_dim != pooled_dim;
+}
+
+void UNetWrapper::setLoraScale(int idx, float v)
+{
+  if(idx < 0 || idx >= num_runtime_loras_)
+    return;
+  if((int)lora_scale_host_.size() < num_runtime_loras_)
+    lora_scale_host_.assign(num_runtime_loras_, 1.0f);
+  if(lora_scale_host_[idx] != v)
+  {
+    lora_scale_host_[idx] = v;
+    lora_scale_dirty_ = true;
+  }
+}
+
+const void* UNetWrapper::loraScaleBufferAddr() const
+{
+  return lora_scale_buffer_ ? (const void*)lora_scale_buffer_->data() : nullptr;
+}
+
+// Bind the runtime lora_scale[N] input (called from forward()/forward_sdxl() before enqueueV3 when the
+// engine declares it). Grow-only device buffer (stable address for CUDA-graph) + PINNED host staging,
+// change-gated H2D (a steady-state graph replay does no copy). The engine's lora_scale is HALF.
+void UNetWrapper::bindLoraScale(cudaStream_t stream)
+{
+  if(!has_lora_scale_ || num_runtime_loras_ <= 0)
+    return;
+  const int N = num_runtime_loras_;
+  if((int)lora_scale_host_.size() < N)
+    lora_scale_host_.resize(N, 1.0f);
+  if(!lora_scale_buffer_ || (int)lora_scale_buffer_->size() < N)
+  {
+    lora_scale_buffer_ = std::make_unique<CUDATensor<__half>>(N);
+    lora_scale_dirty_ = true;
+  }
+  if(lora_scale_pinned_cap_ < N)
+  {
+    if(lora_scale_pinned_)
+      cudaFreeHost(lora_scale_pinned_);
+    cudaMallocHost((void**)&lora_scale_pinned_, N * sizeof(__half));
+    lora_scale_pinned_cap_ = N;
+    lora_scale_dirty_ = true;
+  }
+  if(lora_scale_dirty_)
+  {
+    for(int i = 0; i < N; i++)
+      lora_scale_pinned_[i] = __float2half(lora_scale_host_[i]);
+    cudaMemcpyAsync(lora_scale_buffer_->data(), lora_scale_pinned_, N * sizeof(__half),
+                    cudaMemcpyHostToDevice, stream);
+    lora_scale_dirty_ = false;
+  }
+  nvinfer1::Dims d;
+  d.nbDims = 1;
+  d.d[0] = N;
+  context_->setInputShape("lora_scale", d);
+  context_->setTensorAddress("lora_scale", lora_scale_buffer_->data());
 }
 
 void UNetWrapper::forward(
@@ -413,6 +490,8 @@ void UNetWrapper::forward(
       }
     }
   }
+
+  bindLoraScale(stream);  // runtime-LoRA engines: bind lora_scale[N] (no-op otherwise)
 
   // Enqueue inference
   if(!context_->enqueueV3(stream))
@@ -1198,6 +1277,8 @@ void UNetWrapper::forward_sdxl(
   {
     throw std::runtime_error("Failed to set latent tensor address");
   }
+
+  bindLoraScale(stream);  // runtime-LoRA SDXL engines: bind lora_scale[N] (no-op otherwise)
 
   // Enqueue inference
   if(!context_->enqueueV3(stream))

--- a/src/tensorrt_wrappers.hpp
+++ b/src/tensorrt_wrappers.hpp
@@ -132,6 +132,15 @@ public:
   /// Length of the ipadapter_scale vector (= num cross-attn IP layers), detected at load (0 if none).
   int numIpLayers() const { return num_ip_layers_; }
 
+  /// Runtime LoRA: the engine declares a `lora_scale[N]` HALF input (N = #runtime LoRAs, slot order =
+  /// export CLI order). forward()/forward_sdxl() bind it automatically from the host scales below.
+  bool hasLoraScale() const { return has_lora_scale_; }
+  int numRuntimeLoras() const { return num_runtime_loras_; }
+  /// Set the runtime scale for LoRA slot `idx` (0..N-1). Change-gated (no-op if unchanged).
+  void setLoraScale(int idx, float v);
+  /// Device address of the lora_scale buffer (for the pipeline's CUDA-graph capture_signature).
+  const void* loraScaleBufferAddr() const;
+
   /**
    * Run UNet inference (SD1.5) for an IP-Adapter engine. Identical to forward() except:
    *  - encoder_hidden_states is the EXTENDED sequence [batch, 77+num_image_tokens, hidden_dim] (text
@@ -292,6 +301,18 @@ private:
   float* ipadapter_scale_pinned_ = nullptr;   // cudaMallocHost, length = ipadapter_scale_pinned_cap_
   int ipadapter_scale_pinned_cap_ = 0;
   std::vector<float> ipadapter_scale_last_;    // last host values uploaded (to skip redundant H2D)
+
+  // Runtime LoRA: engine declares a `lora_scale[N]` HALF input. We hold the host scales (default 1.0),
+  // stage them through PINNED host memory, and bind a grow-only device buffer (stable address for
+  // CUDA-graph). bindLoraScale() does the change-gated H2D + binds the input in forward()/forward_sdxl().
+  bool has_lora_scale_ = false;
+  int num_runtime_loras_ = 0;
+  std::vector<float> lora_scale_host_;            // current per-slot scales (size N, init 1.0)
+  std::unique_ptr<CUDATensor<__half>> lora_scale_buffer_;
+  __half* lora_scale_pinned_ = nullptr;
+  int lora_scale_pinned_cap_ = 0;
+  bool lora_scale_dirty_ = true;                  // re-upload H2D only when a scale changed
+  void bindLoraScale(cudaStream_t stream);
 
   void loadEngine(const std::string& engine_path);
   bool needsReallocation(int batch, int height, int width, int seq_len, int hidden_dim, int pooled_dim = 0);

--- a/train-lora.py
+++ b/train-lora.py
@@ -166,29 +166,37 @@ def _splice_lora_scale(onnx_path, out_path, ranks, adapter_names):
                 return i
         return 0
 
-    spliced = []  # (scaling_mul_node, new_mul_node)
+    # lora_B = a MatMul whose weight is 2D with a dim == rank (the rank can be either axis), and whose
+    # output reaches an Add (the residual base+delta) DIRECTLY (fp8: scaling folded into the weight) or
+    # via a single Mul (non-fp8: the PEFT scaling Mul). lora_A also has a rank-dim weight but its output
+    # feeds a Cast/MatMul (the up-projection), not an Add -> it never matches. We splice a
+    # Mul(lora_B_out, lora_scale[slot]) and rewire whatever consumed lora_B_out (the Add, or the scaling Mul).
+    spliced = []  # (anchor_node_to_insert_after, new_mul_node)
     for nd in g.node:
         if nd.op_type != "MatMul":
             continue
-        if not any(shapes.get(inp) and len(shapes[inp]) == 2 and shapes[inp][0] in ranks for inp in nd.input):
+        if not any(shapes.get(inp) and len(shapes[inp]) == 2 and any(d in ranks for d in shapes[inp])
+                   for inp in nd.input):
             continue
-        for mul in [c for c in consumers.get(nd.output[0], []) if c.op_type == "Mul"]:
-            old = mul.output[0]
-            adds = [c for c in consumers.get(old, []) if c.op_type == "Add"]
-            if not adds:
-                continue
-            new_out = old + "_a"
-            for a in adds:
-                for k, inp in enumerate(a.input):
-                    if inp == old:
-                        a.input[k] = new_out
-            spliced.append((mul, helper.make_node("Mul", [old, slot_out[slot_of(nd)]], [new_out],
-                                                   name=old + "/lora_scale_mul")))
-    # rebuild node list: slot gathers first, then originals with each new Mul right after its scaling Mul
+        out = nd.output[0]
+        cons = consumers.get(out, [])
+        reaches_add = any(c.op_type == "Add" for c in cons) or any(
+            c.op_type == "Mul" and any(c2.op_type == "Add" for c2 in consumers.get(c.output[0], []))
+            for c in cons)
+        if not reaches_add:
+            continue  # lora_A (feeds Cast/MatMul) — skip
+        new_out = out + "_a"
+        for c in cons:
+            for k, inp in enumerate(c.input):
+                if inp == out:
+                    c.input[k] = new_out
+        spliced.append((nd, helper.make_node("Mul", [out, slot_out[slot_of(nd)]], [new_out],
+                                              name=out + "/lora_scale_mul")))
+    # rebuild node list: slot gathers first, then originals with each new Mul right after its lora_B MatMul
     nodes = list(g.node)
     pos = {id(n): i for i, n in enumerate(nodes)}
-    for src_mul, nn in sorted(spliced, key=lambda p: pos[id(p[0])], reverse=True):
-        nodes.insert(pos[id(src_mul)] + 1, nn)
+    for anchor, nn in sorted(spliced, key=lambda p: pos[id(p[0])], reverse=True):
+        nodes.insert(pos[id(anchor)] + 1, nn)
     del g.node[:]
     g.node.extend(slot_nodes + nodes)
     onnx.save(m, out_path)
@@ -535,9 +543,16 @@ def main():
         if spec.runtime:
             runtime_adapter_names.append(name)
     has_runtime = bool(runtime_adapter_names)
-    if has_runtime and (args.controlnet or args.ipadapter or args.v2v or args.fp8):
-        raise SystemExit("--lora PATH:runtime is not combinable with --controlnet/--ipadapter/--v2v/--fp8 "
-                         "(plain SD1.5/SDXL only for now).")
+    # Runtime LoRA composes with the feature variants: the trace emits LoRA ops on whichever UNet wrapper
+    # is built below (plain / ControlNet / IP-Adapter / V2V); build_runtime_lora_unet() splices lora_scale
+    # onto that engine's profile, and the C++ forward_* paths all bind lora_scale.
+    # FP8 is NOT supported with runtime LoRA: the modelopt fp8 trace MERGES the LoRA into the weight
+    # (down@up -> Add(base_weight) -> quantize), i.e. weight-space, so a runtime scale would have to
+    # multiply the full [d,d] delta weight every frame for every layer — which defeats the cheap
+    # activation-space scaling that makes runtime LoRA worthwhile. Bake the LoRA (drop :runtime) for fp8.
+    if has_runtime and args.fp8:
+        raise SystemExit("--lora PATH:runtime is not supported with --fp8 (fp8 merges LoRA weight-space). "
+                         "Use a baked LoRA (PATH or PATH:weight) with --fp8, or drop --fp8 for runtime LoRA.")
     if args.lora_specs and not (args.no_fuse_lora or has_runtime):
         # Legacy path: no runtime LoRAs -> fuse everything at the shared --lora-scale (unchanged behavior).
         stream.fuse_lora(fuse_unet=True, fuse_text_encoder=True, lora_scale=args.lora_scale,

--- a/train-lora.py
+++ b/train-lora.py
@@ -105,22 +105,119 @@ class LoraSpec:
     path: str
     weight: float = 1.0
     weight_name: str = None  # HF-repo subfile (e.g. a kohya .safetensors inside a multi-file repo)
+    runtime: bool = False    # ":runtime" -> kept UNFUSED with a per-adapter runtime lora_scale input
 
     @classmethod
     def parse(cls, spec: str) -> "LoraSpec":
         # librediffusion: "repo|weight_name" picks a specific file inside an HF LoRA repo
         # (e.g. ByteDance/Hyper-SD|Hyper-SD15-4steps-lora.safetensors). load_lora forwards
         # weight_name= to diffusers. Distinct '|' separator avoids the path:floatweight ':' clash.
+        wn = None
         if "|" in spec:
-            repo, wn = spec.split("|", 1)
-            return cls(path=repo, weight=1.0, weight_name=wn)
+            spec, wn = spec.split("|", 1)
+        # "PATH:runtime" -> runtime-scalable (engine gets a lora_scale slot); "PATH:0.8" -> baked weight.
         if ":" in spec:
             last = spec.rfind(":")
+            suffix = spec[last + 1:]
+            if suffix == "runtime":
+                return cls(path=spec[:last], weight=1.0, weight_name=wn, runtime=True)
             try:
-                return cls(path=spec[:last], weight=float(spec[last + 1:]))
+                return cls(path=spec[:last], weight=float(suffix), weight_name=wn)
             except ValueError:
                 pass
-        return cls(path=spec, weight=1.0)
+        return cls(path=spec, weight=1.0, weight_name=wn)
+
+
+def _splice_lora_scale(onnx_path, out_path, ranks, adapter_names):
+    """Add a runtime `lora_scale[N]` input to an UNFUSED-LoRA UNet ONNX (N = #runtime adapters).
+
+    Each LoRA branch in the traced graph is  ...-> MatMul(B[r,d]) -> Mul(scaling const) -> Add(base).
+    We multiply each scaled delta by lora_scale[adapter_slot] before the Add. At lora_scale=1 the result
+    is identical to the baked/fused engine; 0 removes that LoRA; in between scales it inside every layer.
+    Branches are detected structurally (lora_B = a MatMul whose weight initializer is 2D with first dim
+    in `ranks`, feeding a Mul that feeds an Add) — the traced graph strips lora names, so we must NOT key
+    on names except to assign the per-adapter slot. Returns (N, n_branches)."""
+    import onnx
+    from onnx import helper, TensorProto
+    from collections import defaultdict
+    m = onnx.load(onnx_path, load_external_data=False)
+    g = m.graph
+    shapes = {i.name: list(i.dims) for i in g.initializer}
+    consumers = defaultdict(list)
+    for nd in g.node:
+        for i in nd.input:
+            consumers[i].append(nd)
+    N = max(1, len(adapter_names))
+    LS = "lora_scale"
+    g.input.append(helper.make_tensor_value_info(LS, TensorProto.FLOAT16, [N]))
+    # one Gather per slot up front: lora_scale[i] -> scalar-ish [1] reused by every branch of adapter i
+    slot_nodes, slot_out = [], []
+    for i in range(N):
+        idx = f"{LS}_idx{i}"; out = f"{LS}_s{i}"
+        g.initializer.append(helper.make_tensor(idx, TensorProto.INT64, [1], [i]))
+        slot_nodes.append(helper.make_node("Gather", [LS, idx], [out], axis=0, name=f"{LS}/gather{i}"))
+        slot_out.append(out)
+
+    def slot_of(node):
+        if N == 1:
+            return 0
+        for i, a in enumerate(adapter_names):
+            if a in node.name:
+                return i
+        return 0
+
+    spliced = []  # (scaling_mul_node, new_mul_node)
+    for nd in g.node:
+        if nd.op_type != "MatMul":
+            continue
+        if not any(shapes.get(inp) and len(shapes[inp]) == 2 and shapes[inp][0] in ranks for inp in nd.input):
+            continue
+        for mul in [c for c in consumers.get(nd.output[0], []) if c.op_type == "Mul"]:
+            old = mul.output[0]
+            adds = [c for c in consumers.get(old, []) if c.op_type == "Add"]
+            if not adds:
+                continue
+            new_out = old + "_a"
+            for a in adds:
+                for k, inp in enumerate(a.input):
+                    if inp == old:
+                        a.input[k] = new_out
+            spliced.append((mul, helper.make_node("Mul", [old, slot_out[slot_of(nd)]], [new_out],
+                                                   name=old + "/lora_scale_mul")))
+    # rebuild node list: slot gathers first, then originals with each new Mul right after its scaling Mul
+    nodes = list(g.node)
+    pos = {id(n): i for i, n in enumerate(nodes)}
+    for src_mul, nn in sorted(spliced, key=lambda p: pos[id(p[0])], reverse=True):
+        nodes.insert(pos[id(src_mul)] + 1, nn)
+    del g.node[:]
+    g.node.extend(slot_nodes + nodes)
+    onnx.save(m, out_path)
+    onnx.checker.check_model(out_path)
+    return N, len(spliced)
+
+
+def build_runtime_lora_unet(wrapped_unet, unet_model, onnx_path, engine_path,
+                            opt_h, opt_w, opt_batch, static_batch, static_shape, ranks, adapter_names):
+    """Export the UNFUSED UNet (LoRA as ops), splice the runtime lora_scale input, build the engine.
+    Bypasses the daydream onnxslim step (which OOMs on >2GB SDXL ONNX) and adds lora_scale to the TRT
+    input profile. Writes a `lora_runtime.json` sidecar so the C++/node know the slot order."""
+    from cuda.bindings import runtime as cudart  # cuda-python 13: cudart under cuda.bindings.runtime
+    from streamdiffusion.acceleration.tensorrt.utilities import export_onnx, Engine
+    export_onnx(wrapped_unet, onnx_path, unet_model, opt_h, opt_w, opt_batch, onnx_opset=19)
+    alpha = onnx_path[:-5] + "_lora.onnx"
+    N, nb = _splice_lora_scale(onnx_path, alpha, ranks, adapter_names)
+    print(f"[runtime-lora] lora_scale[{N}] spliced over {nb} branches; slots={adapter_names}")
+    prof = unet_model.get_input_profile(opt_batch, opt_h, opt_w,
+                                        static_batch=static_batch, static_shape=static_shape)
+    prof["lora_scale"] = ((N,), (N,), (N,))
+    _, free_mem, _ = cudart.cudaMemGetInfo()
+    Engine(engine_path).build(alpha, fp16=True, input_profile=prof,
+                              workspace_size=int(free_mem * 0.75),
+                              timing_cache=engine_path.replace(".engine", ".timing.cache"),
+                              builder_optimization_level=5)
+    # (num_runtime_loras is recorded in bundle.json by write_manifest at the end of main() — the per-engine
+    #  builder cleanup wipes any non-.engine file we'd write into the bundle dir here.)
+    return N
 
 
 def parse_args():
@@ -425,21 +522,44 @@ def main():
 
     stream = StreamDiffusion(pipe, t_index_list=[30, 45], torch_dtype=dtype, cfg_type="none")
 
-    # LoRAs: load + fuse (same as the original / the matrix path).
-    for spec in args.lora_specs:
-        # weight_name selects a specific file inside a multi-file HF repo (kohya LoRAs like
-        # ByteDance/Hyper-SD); load_lora forwards it to diffusers' load_lora_weights.
-        if spec.weight_name:
-            stream.load_lora(spec.path, weight_name=spec.weight_name)
-        else:
-            stream.load_lora(spec.path)
-        print(f"Loaded LoRA: {spec.path} (weight_name={spec.weight_name}, scale {args.lora_scale})")
-    if args.lora_specs and not args.no_fuse_lora:
+    # LoRAs: load each as a named adapter. BAKED ones (PATH or PATH:weight) are fused into the weights;
+    # RUNTIME ones (PATH:runtime) stay active/unfused so the trace emits lora_A/lora_B as ops and a
+    # `lora_scale[N]` engine input drives them per-adapter at inference (see build_runtime_lora_unet).
+    runtime_adapter_names, runtime_ranks = [], set()
+    for i, spec in enumerate(args.lora_specs):
+        name = f"lora{i}"
+        kw = {"weight_name": spec.weight_name} if spec.weight_name else {}
+        stream.load_lora(spec.path, adapter_name=name, **kw)
+        kind = "runtime" if spec.runtime else f"baked@{spec.weight}"
+        print(f"Loaded LoRA[{name}]: {spec.path} (weight_name={spec.weight_name}, {kind})")
+        if spec.runtime:
+            runtime_adapter_names.append(name)
+    has_runtime = bool(runtime_adapter_names)
+    if has_runtime and (args.controlnet or args.ipadapter or args.v2v or args.fp8):
+        raise SystemExit("--lora PATH:runtime is not combinable with --controlnet/--ipadapter/--v2v/--fp8 "
+                         "(plain SD1.5/SDXL only for now).")
+    if args.lora_specs and not (args.no_fuse_lora or has_runtime):
+        # Legacy path: no runtime LoRAs -> fuse everything at the shared --lora-scale (unchanged behavior).
         stream.fuse_lora(fuse_unet=True, fuse_text_encoder=True, lora_scale=args.lora_scale,
                          safe_fusing=False)
-    elif args.lora_specs and args.no_fuse_lora:
-        # Leave the adapter active (default scale 1.0) so the ONNX trace captures lora_A/lora_B as ops.
-        print("[no-fuse-lora] LoRA kept UNFUSED (graph ops, scale=1.0) — runtime-scale experiment")
+    elif args.lora_specs and (args.no_fuse_lora or has_runtime):
+        # Fuse only the BAKED adapters (each at its own weight); keep the runtime adapters active at 1.0.
+        baked = [(f"lora{i}", s) for i, s in enumerate(args.lora_specs) if not s.runtime]
+        for name, s in baked:
+            stream.pipe.fuse_lora(adapter_names=[name], lora_scale=s.weight, safe_fusing=False)
+        if baked:
+            print(f"[runtime-lora] fused baked adapters {[n for n, _ in baked]}")
+        if runtime_adapter_names:
+            stream.pipe.set_adapters(runtime_adapter_names, [1.0] * len(runtime_adapter_names))
+            for n in runtime_adapter_names:
+                r = getattr(stream.unet.peft_config.get(n, None), "r", None)
+                if isinstance(r, dict):
+                    runtime_ranks.update(r.values())
+                elif r:
+                    runtime_ranks.add(r)
+            print(f"[runtime-lora] kept UNFUSED: {runtime_adapter_names}  ranks={sorted(runtime_ranks)}")
+        else:
+            print("[no-fuse-lora] LoRA kept UNFUSED (graph ops, scale=1.0)")
 
     # TinyVAE (matches the original + what the C++ engine expects).
     taesd = "madebyollin/taesdxl" if is_sdxl else "madebyollin/taesd"
@@ -657,8 +777,18 @@ def main():
         os.environ["LRD_FP8_EXPORT"] = "1"   # gate export_onnx/optimize_onnx to preserve Q/DQ
 
     o, oo = onnx_pair("unet")
-    compile_unet(wrapped_unet, unet_model, o, oo, f"{args.output}/unet.engine",
-                 opt_batch_size=args.opt_batch, engine_build_options=build_opts)
+    if has_runtime:
+        # Runtime-LoRA: export UNFUSED, splice the lora_scale[N] input, build (skips onnxslim — which OOMs
+        # on >2GB SDXL ONNX — and adds the lora_scale profile). Plain SD1.5/SDXL only (gated above).
+        wrapped_unet = wrapped_unet.to(device, dtype=dtype)
+        build_runtime_lora_unet(
+            wrapped_unet, unet_model, o, f"{args.output}/unet.engine",
+            args.opt_height, args.opt_width, args.opt_batch,
+            static_batch=static, static_shape=static,
+            ranks=runtime_ranks or {16, 32, 64}, adapter_names=runtime_adapter_names)
+    else:
+        compile_unet(wrapped_unet, unet_model, o, oo, f"{args.output}/unet.engine",
+                     opt_batch_size=args.opt_batch, engine_build_options=build_opts)
     os.environ.pop("LRD_FP8_EXPORT", None)   # scope the flag to the UNet build only
 
     # ---- VAE decoder ----
@@ -741,9 +871,14 @@ def main():
             "ipadapter": bool(args.ipadapter),
             "v2v": bool(args.v2v),                     # kvo extended-self-attention UNet (--v2v)
             "rife": False,
+            "runtime_lora": bool(runtime_adapter_names),
         },
         "controlnet_repo": args.controlnet,
         "ipadapter_ckpt": args.ipadapter,
+        # runtime LoRA: the UNet engine declares a lora_scale[N] input; slot i = the i-th PATH:runtime
+        # LoRA in CLI order. The node exposes one scale knob per slot. 0 = none.
+        "num_runtime_loras": len(runtime_adapter_names),
+        "lora_runtime_slots": [s.path for s in args.lora_specs if s.runtime],
     })
 
     print(f"\nDONE. Engines in {args.output}:")

--- a/train-lora.py
+++ b/train-lora.py
@@ -147,6 +147,10 @@ def parse_args():
     p.add_argument("-o", "--output", default="./engines")
     p.add_argument("-l", "--lora", action="append", dest="loras", default=[], metavar="PATH[:WEIGHT]")
     p.add_argument("--lora-scale", type=float, default=1.0)
+    p.add_argument("--no-fuse-lora", action="store_true",
+                   help="EXPERIMENT: keep the LoRA active as graph ops (unfused) instead of fusing it "
+                        "into the weights. The trace then emits lora_A/lora_B matmuls (scale baked at "
+                        "1.0) — the basis for a runtime lora_scale engine input.")
     # ControlNet: when set, ALSO export a controlnet.engine (the ControlNet model) AND a
     # controlnet-variant unet.engine that has the input_control_NN / input_control_middle residual
     # inputs (ControlNetUNetExportWrapper). The C++ pipeline runs the controlnet engine, then feeds its
@@ -430,9 +434,12 @@ def main():
         else:
             stream.load_lora(spec.path)
         print(f"Loaded LoRA: {spec.path} (weight_name={spec.weight_name}, scale {args.lora_scale})")
-    if args.lora_specs:
+    if args.lora_specs and not args.no_fuse_lora:
         stream.fuse_lora(fuse_unet=True, fuse_text_encoder=True, lora_scale=args.lora_scale,
                          safe_fusing=False)
+    elif args.lora_specs and args.no_fuse_lora:
+        # Leave the adapter active (default scale 1.0) so the ONNX trace captures lora_A/lora_B as ops.
+        print("[no-fuse-lora] LoRA kept UNFUSED (graph ops, scale=1.0) — runtime-scale experiment")
 
     # TinyVAE (matches the original + what the C++ engine expects).
     taesd = "madebyollin/taesdxl" if is_sdxl else "madebyollin/taesd"


### PR DESCRIPTION
Make LoRA strength a **runtime control** instead of a build-time baked weight. Each LoRA is independently **baked** (`--lora PATH` or `PATH:0.8`, fused into the weights as before) or **runtime** (`PATH:runtime`), and runtime LoRAs become a `lora_scale[N]` engine input dialled live at inference — slot `i` = the i-th `PATH:runtime` in CLI order (mirrors `ipadapter_scale`).

## How it works

A baked LoRA folds `W_eff = W0 + α·B·A` into the weights (α frozen). A runtime LoRA is instead kept **unfused** so the trace emits `lora_A/lora_B` as ops; a post-export ONNX surgery splices a `lora_scale[N]` input and multiplies each LoRA's delta by its slot before the residual `Add`. `lora_scale[i]=1` reproduces the baked/fused result **exactly**; `0` removes that LoRA; in between scales it inside every layer.

## Changes

**Export (`train-lora.py`)**
- `LoraSpec` `:runtime` suffix; load all LoRAs as named adapters, fuse only the baked ones (each at its own weight, via `pipe.fuse_lora(adapter_names=)`), keep runtime ones active.
- `_splice_lora_scale()` — structural detection (lora_B = a MatMul whose weight is `[rank,*]` feeding a scaling `Mul → Add`; the traced graph strips lora names, so detect by rank, not name), per-adapter slot via `Gather`.
- `build_runtime_lora_unet()` — `export_onnx → surgery → Engine.build` with the `lora_scale` profile. **Skips onnxslim** (which OOMs on the >2GB SDXL ONNX) and adds `lora_scale[N]` to the TRT input profile.
- `bundle.json` records `num_runtime_loras` + `lora_runtime_slots`. Gated to plain SD1.5/SDXL (not `--controlnet/--ipadapter/--v2v/--fp8`).

**C++**
- `UNetWrapper` detects `lora_scale[N]` (HALF) at load; `bindLoraScale()` in `forward()`/`forward_sdxl()` — grow-only device buffer (stable address for CUDA-graph) + pinned staging, change-gated H2D. Default scales 1.0 (LoRA fully on == a baked engine).
- Pipeline `set_lora_scale(idx)` / `_vector` / `num_runtime_loras`; a value change forces a CUDA-graph recapture (the captured 1-step graph bakes the staged H2D); the buffer is hashed in `capture_signature`.
- C-API + loader: `librediffusion_{num_runtime_loras,set_lora_scale,set_lora_scale_vector}`.

## Validation (crayon_style_lora_sdxl:runtime on SDXL)

- ONNX-level: `lora_scale=1` reproduces the fused output at **99.9 dB**; `0` removes the LoRA.
- Built engine: declares `lora_scale (1,)` HALF; the input is live (meanΔ@0vs@1=0.018).
- Full C++ pipeline (via the C-API): reports 1 runtime LoRA; `set_lora_scale(0,v)` is live — frame mean 175 @1.0 vs 125 @0.0 (**MAD 50**) — at **14.5 fps** SDXL-1024 1-step. The value change itself is free.
- **FPS cost** of the feature vs a fused baseline UNet: **+8.3%** (keeping LoRA unfused breaks TRT's GEMM fusion).

## Follow-ups (not in this PR)

- Per-slot node UI (the C-API/export already support independent per-slot scales).
- Runtime LoRA combined with ControlNet/IP-Adapter/V2V/FP8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)