### PR TITLE
fix: robustness hardening — 14 confirmed crash/corruption defects

### DIFF
--- a/src/cuda_error_state.hpp
+++ b/src/cuda_error_state.hpp
@@ -1,15 +1,9 @@
 // Pending-CUDA-error bookkeeping, shared by every C-API translation unit.
 //
-// CUDA errors come in two kinds and F-03 turned on telling them apart.
-//
-// A PER-CALL failure (cudaErrorMemoryAllocation and friends) is left pending until somebody reads
-// it, and reading it clears it. Left unread it is reported by the NEXT entry point — which did
-// nothing wrong — so a rejected create made the following, entirely valid, create return -4 and the
-// host saw a working bundle refuse to load.
-//
-// A CONTEXT-LEVEL failure (an illegal address, a launch failure, ECC) cannot be cleared at all: the
-// context is dead and every subsequent CUDA call in the process returns it forever. Nothing here can
-// recover from that, so it is reported for what it is rather than retried.
+// A per-call failure (cudaErrorMemoryAllocation and friends) stays pending until somebody reads it,
+// and reading it clears it; unread, it is reported by the next entry point instead. A context-level
+// failure (illegal address, launch failure, ECC) cannot be cleared at all — every subsequent CUDA
+// call in the process returns it forever.
 #pragma once
 
 #include <cuda_runtime.h>

--- a/src/cuda_error_state.hpp
+++ b/src/cuda_error_state.hpp
@@ -4,6 +4,11 @@
 // and reading it clears it; unread, it is reported by the next entry point instead. A context-level
 // failure (illegal address, launch failure, ECC) cannot be cleared at all — every subsequent CUDA
 // call in the process returns it forever.
+//
+// Only errors the CUDA runtime itself declares STICKY belong in cuda_error_is_context_fatal():
+// latching one refuses every later entry point, pipeline_create included, for the life of the
+// process. cudaErrorContextIsDestroyed / cudaErrorDeviceUninitialized are deliberately absent —
+// a host that calls cudaDeviceReset() gets them once and recovers on the next call.
 #pragma once
 
 #include <cuda_runtime.h>
@@ -36,8 +41,8 @@ inline bool cuda_error_is_context_fatal(cudaError_t err)
     case cudaErrorInvalidAddressSpace:
     case cudaErrorInvalidPc:
     case cudaErrorECCUncorrectable:
-    case cudaErrorContextIsDestroyed:
-    case cudaErrorDeviceUninitialized:
+    case cudaErrorNvlinkUncorrectable:
+    case cudaErrorAssert:
       return true;
     default:
       return false;

--- a/src/cuda_error_state.hpp
+++ b/src/cuda_error_state.hpp
@@ -1,0 +1,76 @@
+// Pending-CUDA-error bookkeeping, shared by every C-API translation unit.
+//
+// CUDA errors come in two kinds and F-03 turned on telling them apart.
+//
+// A PER-CALL failure (cudaErrorMemoryAllocation and friends) is left pending until somebody reads
+// it, and reading it clears it. Left unread it is reported by the NEXT entry point — which did
+// nothing wrong — so a rejected create made the following, entirely valid, create return -4 and the
+// host saw a working bundle refuse to load.
+//
+// A CONTEXT-LEVEL failure (an illegal address, a launch failure, ECC) cannot be cleared at all: the
+// context is dead and every subsequent CUDA call in the process returns it forever. Nothing here can
+// recover from that, so it is reported for what it is rather than retried.
+#pragma once
+
+#include <cuda_runtime.h>
+
+#include <atomic>
+#include <cstdio>
+
+namespace librediffusion
+{
+
+inline thread_local cudaError_t g_last_cuda_error = cudaSuccess;
+// Context loss is a property of the CUDA context, not of the calling thread.
+inline std::atomic<bool> g_cuda_context_lost{false};
+
+inline void set_cuda_error(cudaError_t err)
+{
+  g_last_cuda_error = err;
+}
+
+inline bool cuda_error_is_context_fatal(cudaError_t err)
+{
+  switch(err)
+  {
+    case cudaErrorIllegalAddress:
+    case cudaErrorLaunchFailure:
+    case cudaErrorLaunchTimeout:
+    case cudaErrorHardwareStackError:
+    case cudaErrorIllegalInstruction:
+    case cudaErrorMisalignedAddress:
+    case cudaErrorInvalidAddressSpace:
+    case cudaErrorInvalidPc:
+    case cudaErrorECCUncorrectable:
+    case cudaErrorContextIsDestroyed:
+    case cudaErrorDeviceUninitialized:
+      return true;
+    default:
+      return false;
+  }
+}
+
+inline bool cuda_context_lost()
+{
+  return g_cuda_context_lost.load(std::memory_order_relaxed);
+}
+
+// Consume whatever the runtime has pending, so it cannot be attributed to the next call.
+inline cudaError_t drain_cuda_error()
+{
+  cudaError_t err = cudaGetLastError();
+  if(err != cudaSuccess)
+  {
+    set_cuda_error(err);
+    if(cuda_error_is_context_fatal(err))
+    {
+      g_cuda_context_lost.store(true, std::memory_order_relaxed);
+      std::fprintf(
+          stderr, "[librediffusion] CUDA CONTEXT LOST: %s - this process cannot render again\n",
+          cudaGetErrorString(err));
+    }
+  }
+  return err;
+}
+
+} // namespace librediffusion

--- a/src/cuda_tensor.hpp
+++ b/src/cuda_tensor.hpp
@@ -19,19 +19,14 @@ public:
   {
   }
 
-  // Checked allocation. `data_` used to be missing from the member-init list entirely and the
-  // cudaMalloc result was discarded, so a failed allocation (an overflowed size, genuine VRAM
-  // exhaustion) left the object holding an INDETERMINATE pointer that every later kernel and
-  // memcpy dereferenced. Follows the pattern RifeInterpolator::ensureScratch already uses: throw,
-  // so the C boundary turns it into an error code instead of a device fault.
+  // Throws on failure so the C boundary turns it into an error code instead of a device fault.
   explicit CUDATensor(size_t size)
       : data_(nullptr)
       , size_(size)
       , owns_memory_(true)
   {
     const size_t bytes = size * sizeof(T);
-    // size * sizeof(T) must not have wrapped: a caller computing an element count in `int` can hand
-    // us something absurd, and the allocator would happily be asked for a nonsense length.
+    // A caller computing an element count in `int` can wrap size * sizeof(T).
     if(size != 0 && bytes / sizeof(T) != size)
       throw std::runtime_error("CUDATensor: requested element count overflows size_t");
     if(bytes == 0)

--- a/src/cuda_tensor.hpp
+++ b/src/cuda_tensor.hpp
@@ -4,6 +4,7 @@
 #include <cuda_runtime.h>
 #include <nppi.h>
 #include <stdexcept>
+#include <string>
 
 namespace librediffusion
 {
@@ -18,11 +19,32 @@ public:
   {
   }
 
-  CUDATensor(size_t size)
-      : size_(size)
+  // Checked allocation. `data_` used to be missing from the member-init list entirely and the
+  // cudaMalloc result was discarded, so a failed allocation (an overflowed size, genuine VRAM
+  // exhaustion) left the object holding an INDETERMINATE pointer that every later kernel and
+  // memcpy dereferenced. Follows the pattern RifeInterpolator::ensureScratch already uses: throw,
+  // so the C boundary turns it into an error code instead of a device fault.
+  explicit CUDATensor(size_t size)
+      : data_(nullptr)
+      , size_(size)
       , owns_memory_(true)
   {
-    cudaMalloc(&data_, size * sizeof(T));
+    const size_t bytes = size * sizeof(T);
+    // size * sizeof(T) must not have wrapped: a caller computing an element count in `int` can hand
+    // us something absurd, and the allocator would happily be asked for a nonsense length.
+    if(size != 0 && bytes / sizeof(T) != size)
+      throw std::runtime_error("CUDATensor: requested element count overflows size_t");
+    if(bytes == 0)
+      return; // a zero-length tensor is legal and owns nothing
+    cudaError_t e = cudaMalloc(&data_, bytes);
+    if(e != cudaSuccess || !data_)
+    {
+      data_ = nullptr;
+      owns_memory_ = false;
+      throw std::runtime_error(
+          std::string("CUDATensor: cudaMalloc of ") + std::to_string(bytes)
+          + " bytes failed: " + cudaGetErrorString(e));
+    }
   }
 
   CUDATensor(T* data, size_t size)

--- a/src/device_guard.hpp
+++ b/src/device_guard.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+/* Per-handle CUDA device.
+ *
+ * cudaSetDevice sets THREAD state, not process state, so a handle built on one thread and driven
+ * from another (a host's render/worker thread) would otherwise run on whatever device that thread
+ * defaults to — device 0. Each handle records the device it was created on and every entry point
+ * scopes the current device to it, so a call is correct from any thread. */
+
+#include <cuda_runtime.h>
+
+namespace librediffusion
+{
+
+// Sets the current device for the enclosing scope and restores the previous one. A no-op when the
+// thread is already on the right device, which is the common single-GPU case.
+class DeviceGuard
+{
+public:
+  explicit DeviceGuard(int device) noexcept
+  {
+    if(device < 0)
+      return;
+    if(cudaGetDevice(&prev_) != cudaSuccess)
+      return;
+    if(prev_ == device)
+      return;
+    if(cudaSetDevice(device) == cudaSuccess)
+      restore_ = true;
+  }
+  ~DeviceGuard() noexcept
+  {
+    if(restore_)
+      cudaSetDevice(prev_);
+  }
+  DeviceGuard(const DeviceGuard&) = delete;
+  DeviceGuard& operator=(const DeviceGuard&) = delete;
+
+private:
+  int prev_{-1};
+  bool restore_{false};
+};
+
+// The device a *_create was asked for, or -1 when it is not a usable ordinal. Callers turn -1 into
+// their own "invalid argument" result; validating here keeps the message identical everywhere.
+inline int resolve_device(int requested) noexcept
+{
+  int count = 0;
+  if(cudaGetDeviceCount(&count) != cudaSuccess || count <= 0)
+    return -1;
+  if(requested < 0 || requested >= count)
+    return -1;
+  return requested;
+}
+
+} // namespace librediffusion

--- a/src/librediffusion.cpp
+++ b/src/librediffusion.cpp
@@ -4,6 +4,7 @@
 #include "kernels.hpp"
 #include "nchw.hpp"
 
+#include <algorithm>
 #include <cmath>
 
 #include <cassert>
@@ -270,8 +271,11 @@ void LibreDiffusionPipeline::prepare_scheduler(
 
 void LibreDiffusionPipeline::set_init_noise(const __half* noise)
 {
-  // Copy noise from Python to our internal buffer
-  size_t noise_size = init_noise_->size();
+  // Copy only what the caller supplies: init_noise_ is allocated wider than the documented
+  // [noise_batch, 4, lh, lw] input, and reading the surplus would run off the caller's buffer.
+  size_t noise_size = std::min(
+      init_noise_input_elems_ ? init_noise_input_elems_ : init_noise_->size(),
+      init_noise_->size());
   cudaMemcpyAsync(
       init_noise_->data(), noise, noise_size * sizeof(__half), cudaMemcpyDeviceToDevice,
       stream_);

--- a/src/librediffusion.cpp
+++ b/src/librediffusion.cpp
@@ -151,6 +151,22 @@ const char* LibreDiffusionPipeline::inference_readiness() const
   return nullptr;
 }
 
+const char* LibreDiffusionPipeline::encode_readiness() const
+{
+  if(!vae_encoder_)
+    return "no VAE encoder (call librediffusion_pipeline_init_engines, and configure "
+           "vae_encoder_path first)";
+  return nullptr;
+}
+
+const char* LibreDiffusionPipeline::decode_readiness() const
+{
+  if(!vae_decoder_)
+    return "no VAE decoder (call librediffusion_pipeline_init_engines, and configure "
+           "vae_decoder_path first)";
+  return nullptr;
+}
+
 void LibreDiffusionPipeline::prepare_scheduler(
     std::span<float> timesteps, std::span<float> alpha_prod_t_sqrt,
     std::span<float> beta_prod_t_sqrt, std::span<float> c_skip, std::span<float> c_out)

--- a/src/librediffusion.cpp
+++ b/src/librediffusion.cpp
@@ -144,6 +144,12 @@ const char* LibreDiffusionPipeline::inference_readiness() const
      || c_skip_host_.empty() || c_out_host_.empty())
     return "scheduler not prepared (call librediffusion_prepare_scheduler first)";
 
+  // reinit_buffers can raise batch_size / frame_buffer_size after the schedule was uploaded, and the
+  // forwards read sub_timesteps_ by that extent.
+  if(sub_timesteps_->size() < (size_t)timestep_extent())
+    return "the scheduler was prepared for a smaller batch (call librediffusion_prepare_scheduler "
+           "again after changing batch_size or frame_buffer_size)";
+
   // SDXL additionally binds the pooled embeddings and the time ids on every path.
   if(config_.model_type == ModelType::SDXL_TURBO && (!text_embeds_ || !time_ids_))
     return "SDXL conditioning not prepared (call librediffusion_prepare_sdxl_conditioning first)";
@@ -222,21 +228,31 @@ void LibreDiffusionPipeline::prepare_scheduler(
       throw std::runtime_error(
           "prepare_scheduler: alpha_prod_t_sqrt[" + std::to_string(i)
           + "] is zero; it is a divisor on the single-step path");
-  auto reuse = [&](std::unique_ptr<CUDATensor<float>>& b) {
-    if(!b || b->size() != n) { b = std::make_unique<CUDATensor<float>>(n); }
+  auto reuse = [&](std::unique_ptr<CUDATensor<float>>& b, size_t want) {
+    if(!b || b->size() != want) { b = std::make_unique<CUDATensor<float>>(want); }
   };
-  reuse(alpha_prod_t_sqrt_);
-  reuse(beta_prod_t_sqrt_);
-  reuse(c_skip_);
-  reuse(c_out_);
-  reuse(sub_timesteps_);
+  reuse(alpha_prod_t_sqrt_, n);
+  reuse(beta_prod_t_sqrt_, n);
+  reuse(c_skip_, n);
+  reuse(c_out_, n);
+
+  // sub_timesteps_ is the one buffer the UNet paths read by BATCH extent, not by step index: every
+  // forward copies `total_batch` (or batch_size) floats out of it. Those extents equal `n` only when
+  // batch_size == denoising_steps and frame_buffer_size == 1; anywhere else the copy ran past the end
+  // of the allocation. Hold the schedule cycled to the extent the forwards actually read, so `n` rows
+  // stay bit-identical and the surplus rows repeat the schedule instead of reading whatever followed.
+  const size_t extent = std::max(n, (size_t)timestep_extent());
+  reuse(sub_timesteps_, extent);
+  std::vector<float> cycled(extent);
+  for(size_t i = 0; i < extent; i++)
+    cycled[i] = timesteps[i % n];
 
   // Copy scheduler parameters to device
   cudaMemcpy(alpha_prod_t_sqrt_->data(), alpha_prod_t_sqrt_host_.data(), n * sizeof(float), cudaMemcpyHostToDevice);
   cudaMemcpy(beta_prod_t_sqrt_->data(), beta_prod_t_sqrt_host_.data(), n * sizeof(float), cudaMemcpyHostToDevice);
   cudaMemcpy(c_skip_->data(), c_skip_host_.data(), n * sizeof(float), cudaMemcpyHostToDevice);
   cudaMemcpy(c_out_->data(), c_out_host_.data(), n * sizeof(float), cudaMemcpyHostToDevice);
-  cudaMemcpy(sub_timesteps_->data(), timesteps.data(), n * sizeof(float), cudaMemcpyHostToDevice);
+  cudaMemcpy(sub_timesteps_->data(), cycled.data(), extent * sizeof(float), cudaMemcpyHostToDevice);
 
   cudaStreamSynchronize(stream_);
 

--- a/src/librediffusion.cpp
+++ b/src/librediffusion.cpp
@@ -91,6 +91,26 @@ void LibreDiffusionPipeline::set_delta(float g)
   config_.delta = g;
 }
 
+const char* LibreDiffusionPipeline::inference_readiness() const
+{
+  // Conditioning: every UNet forward reads prompt_embeds_->data() unconditionally.
+  if(!prompt_embeds_)
+    return "prompt embeddings not prepared (call librediffusion_prepare_embeds first)";
+
+  // Scheduler: sub_timesteps_ is the device timestep buffer every forward binds, and the four
+  // coefficient vectors are indexed host-side ([0] on the 1-step turbo path, [i] on the multi-step
+  // one). An empty vector's data() is nullptr, so [0] is a null read, not merely a wrong number.
+  if(!sub_timesteps_ || alpha_prod_t_sqrt_host_.empty() || beta_prod_t_sqrt_host_.empty()
+     || c_skip_host_.empty() || c_out_host_.empty())
+    return "scheduler not prepared (call librediffusion_prepare_scheduler first)";
+
+  // SDXL additionally binds the pooled embeddings and the time ids on every path.
+  if(config_.model_type == ModelType::SDXL_TURBO && (!text_embeds_ || !time_ids_))
+    return "SDXL conditioning not prepared (call librediffusion_prepare_sdxl_conditioning first)";
+
+  return nullptr;
+}
+
 void LibreDiffusionPipeline::prepare_scheduler(
     std::span<float> timesteps, std::span<float> alpha_prod_t_sqrt,
     std::span<float> beta_prod_t_sqrt, std::span<float> c_skip, std::span<float> c_out)

--- a/src/librediffusion.cpp
+++ b/src/librediffusion.cpp
@@ -401,8 +401,15 @@ int LibreDiffusionPipeline::num_runtime_loras() const
 
 void LibreDiffusionPipeline::set_lora_scale(int idx, float scale)
 {
-  if(unet_)
-    unet_->setLoraScale(idx, scale);
+  // UNetWrapper::setLoraScale bounds-checks and returns silently, so a host that asked for a slot the
+  // engine does not have was told the scale had been applied. An engine with no runtime LoRA at all
+  // has zero slots, and every set on it was a no-op reported as success.
+  const int slots = num_runtime_loras();
+  if(idx < 0 || idx >= slots)
+    throw std::out_of_range(
+        "set_lora_scale: slot " + std::to_string(idx) + " but the UNet engine declares "
+        + std::to_string(slots) + " runtime LoRA slot(s)");
+  unet_->setLoraScale(idx, scale);
   // The captured 1-step CUDA graph bakes the lora_scale H2D (contents staged before enqueue). A value
   // change must re-stage -> force a recapture (the buffer address is stable + hashed in capture_signature,
   // so a no-op set leaves the graph intact). Same discipline as a prompt/scheduler change.
@@ -411,9 +418,13 @@ void LibreDiffusionPipeline::set_lora_scale(int idx, float scale)
 
 void LibreDiffusionPipeline::set_lora_scale_vector(const float* scales, int n)
 {
-  if(unet_)
-    for(int i = 0; i < n; i++)
-      unet_->setLoraScale(i, scales[i]);
+  const int slots = num_runtime_loras();
+  if(n < 0 || n > slots)
+    throw std::out_of_range(
+        "set_lora_scale_vector: " + std::to_string(n) + " scales but the UNet engine declares "
+        + std::to_string(slots) + " runtime LoRA slot(s)");
+  for(int i = 0; i < n; i++)
+    unet_->setLoraScale(i, scales[i]);
   graph_ready_ = false;
 }
 

--- a/src/librediffusion.cpp
+++ b/src/librediffusion.cpp
@@ -191,6 +191,37 @@ void LibreDiffusionPipeline::prepare_scheduler(
         + " timesteps but the pipeline is configured for "
         + std::to_string(config_.denoising_steps)
         + " denoising steps (reinit_buffers with the new step count first)");
+
+  // Values, not just counts. NaN and inf propagate through the whole latent in one multiply and the
+  // frame comes back pure white (mean 255, std 0) with LIBREDIFFUSION_SUCCESS; alpha == 0 is a
+  // DIVISOR on the turbo path (x_0_pred /= alpha) and yields mean 249 / std 35. A host automating a
+  // coefficient through a bad value was told nothing at all. Timestep VALUES stay unconstrained
+  // beyond finiteness — -999 and 1e30 both produce ordinary frames, so they are not our business.
+  // NOTE: the library is compiled with -ffast-math, so std::isfinite() and `x == 0.f` are NOT
+  // reliable here — the compiler is allowed to assume no NaN/inf exists, which is precisely the
+  // assumption these inputs violate. Inspect the IEEE-754 bits instead.
+  auto bits = [](float f) {
+    unsigned int u = 0;
+    std::memcpy(&u, &f, sizeof(u));
+    return u;
+  };
+  auto reject_non_finite = [&](std::span<float> v, const char* name) {
+    for(size_t i = 0; i < v.size(); i++)
+      if((bits(v[i]) & 0x7F800000u) == 0x7F800000u) // exponent all ones => inf or NaN
+        throw std::runtime_error(
+            std::string("prepare_scheduler: ") + name + "[" + std::to_string(i)
+            + "] is not a finite number");
+  };
+  reject_non_finite(timesteps, "timesteps");
+  reject_non_finite(alpha_prod_t_sqrt, "alpha_prod_t_sqrt");
+  reject_non_finite(beta_prod_t_sqrt, "beta_prod_t_sqrt");
+  reject_non_finite(c_skip, "c_skip");
+  reject_non_finite(c_out, "c_out");
+  for(size_t i = 0; i < alpha_prod_t_sqrt.size(); i++)
+    if((bits(alpha_prod_t_sqrt[i]) & 0x7FFFFFFFu) == 0u) // +0.0 or -0.0
+      throw std::runtime_error(
+          "prepare_scheduler: alpha_prod_t_sqrt[" + std::to_string(i)
+          + "] is zero; it is a divisor on the single-step path");
   auto reuse = [&](std::unique_ptr<CUDATensor<float>>& b) {
     if(!b || b->size() != n) { b = std::make_unique<CUDATensor<float>>(n); }
   };

--- a/src/librediffusion.cpp
+++ b/src/librediffusion.cpp
@@ -98,6 +98,39 @@ void LibreDiffusionPipeline::set_delta(float g)
   config_.delta = g;
 }
 
+namespace
+{
+// One place for the bounds check so every coefficient read reports the same way: a clear exception
+// naming the array and both indices, which the C API turns into an error code, instead of an
+// unchecked read past the end of a std::vector.
+inline float coeff_at(const std::vector<float>& v, int i, const char* name)
+{
+  if(i < 0 || (size_t)i >= v.size())
+    throw std::out_of_range(
+        std::string("scheduler coefficient ") + name + "[" + std::to_string(i)
+        + "] out of range (schedule has " + std::to_string(v.size())
+        + " entries) — prepare_scheduler was not called with a schedule of this length");
+  return v[(size_t)i];
+}
+} // namespace
+
+float LibreDiffusionPipeline::alpha_at(int i) const
+{
+  return coeff_at(alpha_prod_t_sqrt_host_, i, "alpha_prod_t_sqrt");
+}
+float LibreDiffusionPipeline::beta_at(int i) const
+{
+  return coeff_at(beta_prod_t_sqrt_host_, i, "beta_prod_t_sqrt");
+}
+float LibreDiffusionPipeline::c_skip_at(int i) const
+{
+  return coeff_at(c_skip_host_, i, "c_skip");
+}
+float LibreDiffusionPipeline::c_out_at(int i) const
+{
+  return coeff_at(c_out_host_, i, "c_out");
+}
+
 const char* LibreDiffusionPipeline::inference_readiness() const
 {
   // Conditioning: every UNet forward reads prompt_embeds_->data() unconditionally.
@@ -143,6 +176,21 @@ void LibreDiffusionPipeline::prepare_scheduler(
   if(alpha_prod_t_sqrt.size() != n || beta_prod_t_sqrt.size() != n
      || c_skip.size() != n || c_out.size() != n)
     throw std::runtime_error("prepare_scheduler: coefficient spans must all match timesteps.size()");
+  if(n == 0)
+    throw std::runtime_error("prepare_scheduler: an empty schedule is not a schedule");
+  // ...and they must also match config_.denoising_steps, which is what the denoise loops iterate and
+  // what init_buffers()/reinit_buffers() sized every batch buffer from. The equal-span guard above
+  // only compares the five arrays to EACH OTHER; a schedule shorter than the declared step count used
+  // to render silently (denoising_steps=2 against a 1-entry schedule returned SUCCESS and a plausible
+  // frame while reading alpha_prod_t_sqrt_host_[1] past the end of a 1-element vector). A genuine
+  // step-count change goes through reinit_buffers FIRST — which sets denoising_steps and reallocates —
+  // and only then pushes the matching schedule, so this never fires on a legitimate live update.
+  if((int)n != config_.denoising_steps)
+    throw std::runtime_error(
+        "prepare_scheduler: schedule has " + std::to_string(n)
+        + " timesteps but the pipeline is configured for "
+        + std::to_string(config_.denoising_steps)
+        + " denoising steps (reinit_buffers with the new step count first)");
   auto reuse = [&](std::unique_ptr<CUDATensor<float>>& b) {
     if(!b || b->size() != n) { b = std::make_unique<CUDATensor<float>>(n); }
   };

--- a/src/librediffusion.cpp
+++ b/src/librediffusion.cpp
@@ -37,10 +37,8 @@ LibreDiffusionPipeline::LibreDiffusionPipeline(const LibreDiffusionConfig& confi
 
 LibreDiffusionPipeline::~LibreDiffusionPipeline()
 {
-  // Drain the stream FIRST. Every buffer below (and every TensorRT context the members own) may
-  // still be referenced by work this stream has not run yet — img2img in particular ends with an
-  // async D2H into the CALLER's host buffer. Destroying while that is in flight is a use-after-free
-  // in both directions; a destroy racing an in-flight frame is exactly how a host tears a node down.
+  // Drain the stream first: the buffers and TensorRT contexts below may still be referenced by
+  // queued work, and img2img ends with an async D2H into the CALLER's host buffer.
   if(stream_)
     cudaStreamSynchronize(stream_);
 
@@ -100,9 +98,6 @@ void LibreDiffusionPipeline::set_delta(float g)
 
 namespace
 {
-// One place for the bounds check so every coefficient read reports the same way: a clear exception
-// naming the array and both indices, which the C API turns into an error code, instead of an
-// unchecked read past the end of a std::vector.
 inline float coeff_at(const std::vector<float>& v, int i, const char* name)
 {
   if(i < 0 || (size_t)i >= v.size())
@@ -137,9 +132,8 @@ const char* LibreDiffusionPipeline::inference_readiness() const
   if(!prompt_embeds_)
     return "prompt embeddings not prepared (call librediffusion_prepare_embeds first)";
 
-  // Scheduler: sub_timesteps_ is the device timestep buffer every forward binds, and the four
-  // coefficient vectors are indexed host-side ([0] on the 1-step turbo path, [i] on the multi-step
-  // one). An empty vector's data() is nullptr, so [0] is a null read, not merely a wrong number.
+  // Scheduler: sub_timesteps_ is the device buffer every forward binds; the coefficient vectors are
+  // indexed host-side, and an empty vector's data() is nullptr, so [0] is a null read.
   if(!sub_timesteps_ || alpha_prod_t_sqrt_host_.empty() || beta_prod_t_sqrt_host_.empty()
      || c_skip_host_.empty() || c_out_host_.empty())
     return "scheduler not prepared (call librediffusion_prepare_scheduler first)";
@@ -184,13 +178,9 @@ void LibreDiffusionPipeline::prepare_scheduler(
     throw std::runtime_error("prepare_scheduler: coefficient spans must all match timesteps.size()");
   if(n == 0)
     throw std::runtime_error("prepare_scheduler: an empty schedule is not a schedule");
-  // ...and they must also match config_.denoising_steps, which is what the denoise loops iterate and
-  // what init_buffers()/reinit_buffers() sized every batch buffer from. The equal-span guard above
-  // only compares the five arrays to EACH OTHER; a schedule shorter than the declared step count used
-  // to render silently (denoising_steps=2 against a 1-entry schedule returned SUCCESS and a plausible
-  // frame while reading alpha_prod_t_sqrt_host_[1] past the end of a 1-element vector). A genuine
-  // step-count change goes through reinit_buffers FIRST — which sets denoising_steps and reallocates —
-  // and only then pushes the matching schedule, so this never fires on a legitimate live update.
+  // ...and they must match config_.denoising_steps, which is what the denoise loops iterate and what
+  // init_buffers()/reinit_buffers() sized every batch buffer from. A step-count change goes through
+  // reinit_buffers first, so this never fires on a legitimate live update.
   if((int)n != config_.denoising_steps)
     throw std::runtime_error(
         "prepare_scheduler: schedule has " + std::to_string(n)
@@ -198,14 +188,10 @@ void LibreDiffusionPipeline::prepare_scheduler(
         + std::to_string(config_.denoising_steps)
         + " denoising steps (reinit_buffers with the new step count first)");
 
-  // Values, not just counts. NaN and inf propagate through the whole latent in one multiply and the
-  // frame comes back pure white (mean 255, std 0) with LIBREDIFFUSION_SUCCESS; alpha == 0 is a
-  // DIVISOR on the turbo path (x_0_pred /= alpha) and yields mean 249 / std 35. A host automating a
-  // coefficient through a bad value was told nothing at all. Timestep VALUES stay unconstrained
-  // beyond finiteness — -999 and 1e30 both produce ordinary frames, so they are not our business.
+  // NaN/inf propagate through the whole latent in one multiply; alpha == 0 is a divisor on the
+  // 1-step turbo path. Timestep VALUES stay unconstrained beyond finiteness.
   // NOTE: the library is compiled with -ffast-math, so std::isfinite() and `x == 0.f` are NOT
-  // reliable here — the compiler is allowed to assume no NaN/inf exists, which is precisely the
-  // assumption these inputs violate. Inspect the IEEE-754 bits instead.
+  // usable here — the compiler may assume no NaN/inf exists. Inspect the IEEE-754 bits instead.
   auto bits = [](float f) {
     unsigned int u = 0;
     std::memcpy(&u, &f, sizeof(u));
@@ -237,10 +223,9 @@ void LibreDiffusionPipeline::prepare_scheduler(
   reuse(c_out_, n);
 
   // sub_timesteps_ is the one buffer the UNet paths read by BATCH extent, not by step index: every
-  // forward copies `total_batch` (or batch_size) floats out of it. Those extents equal `n` only when
-  // batch_size == denoising_steps and frame_buffer_size == 1; anywhere else the copy ran past the end
-  // of the allocation. Hold the schedule cycled to the extent the forwards actually read, so `n` rows
-  // stay bit-identical and the surplus rows repeat the schedule instead of reading whatever followed.
+  // forward copies `total_batch` (or batch_size) floats out of it, which equals `n` only when
+  // batch_size == denoising_steps and frame_buffer_size == 1. Hold the schedule cycled to the extent
+  // the forwards actually read, so the first `n` rows stay bit-identical.
   const size_t extent = std::max(n, (size_t)timestep_extent());
   reuse(sub_timesteps_, extent);
   std::vector<float> cycled(extent);
@@ -401,9 +386,7 @@ int LibreDiffusionPipeline::num_runtime_loras() const
 
 void LibreDiffusionPipeline::set_lora_scale(int idx, float scale)
 {
-  // UNetWrapper::setLoraScale bounds-checks and returns silently, so a host that asked for a slot the
-  // engine does not have was told the scale had been applied. An engine with no runtime LoRA at all
-  // has zero slots, and every set on it was a no-op reported as success.
+  // UNetWrapper::setLoraScale bounds-checks and returns silently, so refuse the slot here instead.
   const int slots = num_runtime_loras();
   if(idx < 0 || idx >= slots)
     throw std::out_of_range(

--- a/src/librediffusion.cpp
+++ b/src/librediffusion.cpp
@@ -37,6 +37,13 @@ LibreDiffusionPipeline::LibreDiffusionPipeline(const LibreDiffusionConfig& confi
 
 LibreDiffusionPipeline::~LibreDiffusionPipeline()
 {
+  // Drain the stream FIRST. Every buffer below (and every TensorRT context the members own) may
+  // still be referenced by work this stream has not run yet — img2img in particular ends with an
+  // async D2H into the CALLER's host buffer. Destroying while that is in flight is a use-after-free
+  // in both directions; a destroy racing an in-flight frame is exactly how a host tears a node down.
+  if(stream_)
+    cudaStreamSynchronize(stream_);
+
   if(graph_exec_)
     cudaGraphExecDestroy(graph_exec_);
   if(graph_)

--- a/src/librediffusion.cpp
+++ b/src/librediffusion.cpp
@@ -175,14 +175,15 @@ void LibreDiffusionPipeline::prepare_scheduler(
   // reinit_buffers (which sets denoising_steps AND reallocates).
   if(alpha_prod_t_sqrt.size() != n || beta_prod_t_sqrt.size() != n
      || c_skip.size() != n || c_out.size() != n)
-    throw std::runtime_error("prepare_scheduler: coefficient spans must all match timesteps.size()");
+    throw invalid_dimensions_error(
+        "prepare_scheduler: coefficient spans must all match timesteps.size()");
   if(n == 0)
-    throw std::runtime_error("prepare_scheduler: an empty schedule is not a schedule");
+    throw invalid_argument_error("prepare_scheduler: an empty schedule is not a schedule");
   // ...and they must match config_.denoising_steps, which is what the denoise loops iterate and what
   // init_buffers()/reinit_buffers() sized every batch buffer from. A step-count change goes through
   // reinit_buffers first, so this never fires on a legitimate live update.
   if((int)n != config_.denoising_steps)
-    throw std::runtime_error(
+    throw invalid_dimensions_error(
         "prepare_scheduler: schedule has " + std::to_string(n)
         + " timesteps but the pipeline is configured for "
         + std::to_string(config_.denoising_steps)
@@ -200,7 +201,7 @@ void LibreDiffusionPipeline::prepare_scheduler(
   auto reject_non_finite = [&](std::span<float> v, const char* name) {
     for(size_t i = 0; i < v.size(); i++)
       if((bits(v[i]) & 0x7F800000u) == 0x7F800000u) // exponent all ones => inf or NaN
-        throw std::runtime_error(
+        throw invalid_argument_error(
             std::string("prepare_scheduler: ") + name + "[" + std::to_string(i)
             + "] is not a finite number");
   };
@@ -211,7 +212,7 @@ void LibreDiffusionPipeline::prepare_scheduler(
   reject_non_finite(c_out, "c_out");
   for(size_t i = 0; i < alpha_prod_t_sqrt.size(); i++)
     if((bits(alpha_prod_t_sqrt[i]) & 0x7FFFFFFFu) == 0u) // +0.0 or -0.0
-      throw std::runtime_error(
+      throw invalid_argument_error(
           "prepare_scheduler: alpha_prod_t_sqrt[" + std::to_string(i)
           + "] is zero; it is a divisor on the single-step path");
   auto reuse = [&](std::unique_ptr<CUDATensor<float>>& b, size_t want) {

--- a/src/librediffusion.hpp
+++ b/src/librediffusion.hpp
@@ -96,6 +96,10 @@ struct LibreDiffusionConfig
   // Image tokens are computed HOST-SIDE and fed in via the C-API (external, like controlnet preproc).
   int ipadapter_num_tokens = 4;       // image tokens appended to the 77 text tokens (4 base / 16 plus)
   float ipadapter_scale = 1.0f;       // uniform per-layer scale (overridable per-layer via the C-API)
+  // Did the HOST ask for IP-Adapter? The two fields above have usable defaults, so they cannot tell
+  // us. Set by librediffusion_config_set_ipadapter. When true and the UNet engine turns out not to
+  // be an IP variant, init_engines() reports it instead of silently rendering plain frames (L-15).
+  bool ipadapter_requested = false;
   // On-device IP-Adapter image encoder (optional). When BOTH paths are set, the pipeline loads a
   // CLIPImageEncoderWrapper so the host can feed a RAW style image (set_ipadapter_image) instead of
   // precomputed tokens. clip_image_encoder = CLIP ViT-H/14 (pixel_values[1,3,224,224]->image_embeds

--- a/src/librediffusion.hpp
+++ b/src/librediffusion.hpp
@@ -235,6 +235,27 @@ public:
   // (the C API turns that into LIBREDIFFUSION_ERROR_NOT_INITIALIZED).
   const char* inference_readiness() const;
 
+  // Number of denoise iterations that are actually backed by scheduler coefficients.
+  //
+  // config_.denoising_steps and the length of the five coefficient vectors are two independent
+  // pieces of state; the denoise loops iterated the former and indexed the latter, so a schedule
+  // shorter than the declared step count read past the end of a std::vector on every frame and
+  // rendered a plausible-looking frame with SUCCESS. prepare_scheduler() now refuses a length that
+  // disagrees with config_.denoising_steps, so these are equal in practice — taking the min keeps
+  // every loop in bounds even if some future path lets them drift apart again.
+  int denoise_steps() const
+  {
+    const int n = (int)alpha_prod_t_sqrt_host_.size();
+    return config_.denoising_steps < n ? config_.denoising_steps : n;
+  }
+
+  // Bounds-checked scheduler coefficients. These were raw std::vector operator[]: for i >= size()
+  // an unchecked read past the end, and for an EMPTY vector a null dereference (data() == nullptr).
+  float alpha_at(int i) const;
+  float beta_at(int i) const;
+  float c_skip_at(int i) const;
+  float c_out_at(int i) const;
+
   // Set initial noise from Python (for testing/validation)
   void set_init_noise(const __half* noise); // [denoising_steps, 4, latent_h, latent_w]
 

--- a/src/librediffusion.hpp
+++ b/src/librediffusion.hpp
@@ -253,6 +253,11 @@ public:
   // missing (the C API turns that into LIBREDIFFUSION_ERROR_NOT_INITIALIZED).
   const char* inference_readiness() const;
 
+  // Narrower forms for the standalone VAE entry points, which need neither conditioning nor a
+  // schedule -- only the engine they drive. Same contract as inference_readiness().
+  const char* encode_readiness() const;
+  const char* decode_readiness() const;
+
   /// Number of timestep entries the UNet paths copy out of sub_timesteps_ per forward.
   int timestep_extent() const
   {

--- a/src/librediffusion.hpp
+++ b/src/librediffusion.hpp
@@ -191,6 +191,10 @@ public:
    */
   void reinit_buffers(const LibreDiffusionConfig& new_config);
 
+  /// Empty if the LOADED engines' optimization profiles admit `cfg`'s geometry, otherwise why not.
+  /// reinit_buffers cannot reload an engine, so a geometry outside them is unusable.
+  std::string geometry_rejection(const LibreDiffusionConfig& cfg) const;
+
   // Prepare the pipeline with prompt embeddings and scheduler parameters
   void prepare_embeds(
       const __half* prompt_embeds, // [batch_size, seq_len, hidden_dim]

--- a/src/librediffusion.hpp
+++ b/src/librediffusion.hpp
@@ -225,6 +225,16 @@ public:
       std::span<float> c_out              // [num_timesteps] - output scaling
   );
 
+  // Is the pipeline in a state where txt2img()/img2img() can legally run?
+  //
+  // The constructor brings up CUDA, the engines and the buffers, and then reports success — but it
+  // does NOT bring up the conditioning (prepare_embeds) or the scheduler coefficients
+  // (prepare_scheduler). Those arrive later, from the host, and nothing used to record that they had
+  // not arrived: an inference call at that moment dereferenced a null unique_ptr and indexed an
+  // empty std::vector. Returns nullptr when ready, otherwise a static string naming what is missing
+  // (the C API turns that into LIBREDIFFUSION_ERROR_NOT_INITIALIZED).
+  const char* inference_readiness() const;
+
   // Set initial noise from Python (for testing/validation)
   void set_init_noise(const __half* noise); // [denoising_steps, 4, latent_h, latent_w]
 

--- a/src/librediffusion.hpp
+++ b/src/librediffusion.hpp
@@ -97,8 +97,7 @@ struct LibreDiffusionConfig
   int ipadapter_num_tokens = 4;       // image tokens appended to the 77 text tokens (4 base / 16 plus)
   float ipadapter_scale = 1.0f;       // uniform per-layer scale (overridable per-layer via the C-API)
   // Did the HOST ask for IP-Adapter? The two fields above have usable defaults, so they cannot tell
-  // us. Set by librediffusion_config_set_ipadapter. When true and the UNet engine turns out not to
-  // be an IP variant, init_engines() reports it instead of silently rendering plain frames (L-15).
+  // us. Set by librediffusion_config_set_ipadapter; init_engines() rejects a non-IP UNet when set.
   bool ipadapter_requested = false;
   // On-device IP-Adapter image encoder (optional). When BOTH paths are set, the pipeline loads a
   // CLIPImageEncoderWrapper so the host can feed a RAW style image (set_ipadapter_image) instead of
@@ -233,14 +232,10 @@ public:
       std::span<float> c_out              // [num_timesteps] - output scaling
   );
 
-  // Is the pipeline in a state where txt2img()/img2img() can legally run?
-  //
-  // The constructor brings up CUDA, the engines and the buffers, and then reports success — but it
-  // does NOT bring up the conditioning (prepare_embeds) or the scheduler coefficients
-  // (prepare_scheduler). Those arrive later, from the host, and nothing used to record that they had
-  // not arrived: an inference call at that moment dereferenced a null unique_ptr and indexed an
-  // empty std::vector. Returns nullptr when ready, otherwise a static string naming what is missing
-  // (the C API turns that into LIBREDIFFUSION_ERROR_NOT_INITIALIZED).
+  // Is the pipeline in a state where txt2img()/img2img() can legally run? The constructor brings up
+  // CUDA, the engines and the buffers but NOT the conditioning or the scheduler coefficients, which
+  // arrive later from the host. Returns nullptr when ready, else a static string naming what is
+  // missing (the C API turns that into LIBREDIFFUSION_ERROR_NOT_INITIALIZED).
   const char* inference_readiness() const;
 
   /// Number of timestep entries the UNet paths copy out of sub_timesteps_ per forward.
@@ -250,22 +245,16 @@ public:
            + (config_.denoising_steps - 1) * config_.frame_buffer_size;
   }
 
-  // Number of denoise iterations that are actually backed by scheduler coefficients.
-  //
-  // config_.denoising_steps and the length of the five coefficient vectors are two independent
-  // pieces of state; the denoise loops iterated the former and indexed the latter, so a schedule
-  // shorter than the declared step count read past the end of a std::vector on every frame and
-  // rendered a plausible-looking frame with SUCCESS. prepare_scheduler() now refuses a length that
-  // disagrees with config_.denoising_steps, so these are equal in practice — taking the min keeps
-  // every loop in bounds even if some future path lets them drift apart again.
+  // Denoise iterations actually backed by scheduler coefficients. config_.denoising_steps and the
+  // coefficient-vector length are independent state; prepare_scheduler() refuses a disagreement, so
+  // the min is a belt-and-braces bound for the loops that index both.
   int denoise_steps() const
   {
     const int n = (int)alpha_prod_t_sqrt_host_.size();
     return config_.denoising_steps < n ? config_.denoising_steps : n;
   }
 
-  // Bounds-checked scheduler coefficients. These were raw std::vector operator[]: for i >= size()
-  // an unchecked read past the end, and for an EMPTY vector a null dereference (data() == nullptr).
+  // Bounds-checked scheduler coefficients (throw rather than index past the end).
   float alpha_at(int i) const;
   float beta_at(int i) const;
   float c_skip_at(int i) const;

--- a/src/librediffusion.hpp
+++ b/src/librediffusion.hpp
@@ -433,6 +433,9 @@ public:
 
   std::unique_ptr<CUDATensor<__half>> x_t_latent_buffer_;
   std::unique_ptr<CUDATensor<__half>> init_noise_;
+  // Elements set_init_noise() may read from the caller. init_noise_ itself is allocated wider (the
+  // extent cfg-self / add_noise read at); the caller only supplies the documented rows.
+  size_t init_noise_input_elems_{};
   std::unique_ptr<CUDATensor<__half>> stock_noise_;
   std::unique_ptr<CUDATensor<__half>> stock_noise_rotated_;  // grow-only scratch for the per-step rotation
   std::unique_ptr<CUDATensor<__half>> prompt_embeds_;

--- a/src/librediffusion.hpp
+++ b/src/librediffusion.hpp
@@ -16,11 +16,26 @@
 #include <deque>
 #include <memory>
 #include <span>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
 namespace librediffusion
 {
+
+// Argument rejections, as opposed to internal failures. try_catch_wrapper maps these to
+// LIBREDIFFUSION_ERROR_INVALID_ARGUMENT / _INVALID_DIMENSIONS; a plain std::runtime_error thrown
+// from the same place collapses to -99 INTERNAL, which tells the caller nothing about whose fault
+// it is and is indistinguishable from a TensorRT failure.
+struct invalid_argument_error : std::invalid_argument
+{
+  using std::invalid_argument::invalid_argument;
+};
+
+struct invalid_dimensions_error : std::invalid_argument
+{
+  using std::invalid_argument::invalid_argument;
+};
 
 // Forward declarations
 class UNetWrapper;

--- a/src/librediffusion.hpp
+++ b/src/librediffusion.hpp
@@ -239,6 +239,13 @@ public:
   // (the C API turns that into LIBREDIFFUSION_ERROR_NOT_INITIALIZED).
   const char* inference_readiness() const;
 
+  /// Number of timestep entries the UNet paths copy out of sub_timesteps_ per forward.
+  int timestep_extent() const
+  {
+    return config_.batch_size
+           + (config_.denoising_steps - 1) * config_.frame_buffer_size;
+  }
+
   // Number of denoise iterations that are actually backed by scheduler coefficients.
   //
   // config_.denoising_steps and the length of the five coefficient vectors are two independent

--- a/src/librediffusion.images.cpp
+++ b/src/librediffusion.images.cpp
@@ -152,7 +152,6 @@ void LibreDiffusionPipeline::rgba_resize(
 float*
 LibreDiffusionPipeline::img_preprocess(const uint8_t* device_rgba_input, int iw, int ih)
 {
-  // FIXME batch not handled
   uint8_t* device_rgba_input_correct_size{};
   // SHAPE, not area. This used to compare iw*ih against width*height, so 1024x256 was accepted as
   // "already 512x512" and processed with the wrong strides — silently scrambled rather than resized.
@@ -167,6 +166,15 @@ LibreDiffusionPipeline::img_preprocess(const uint8_t* device_rgba_input, int iw,
         this->config_.width, this->config_.height);
     device_rgba_input_correct_size = device_rgba_input_vae_size_->data();
   }
+
+  // Exactly ONE frame reaches this buffer — img2img uploads one, rgba_resize writes one — while the
+  // conversion below and the VAE encoder both run config_.batch_size rows. Replicate it rather than
+  // hand rows 1..batch-1 to whatever the allocator last left in that VRAM.
+  const size_t frame_bytes = (size_t)this->config_.width * this->config_.height * 4;
+  for(int i = 1; i < this->config_.batch_size; i++)
+    cudaMemcpyAsync(
+        device_rgba_input_correct_size + (size_t)i * frame_bytes,
+        device_rgba_input_correct_size, frame_bytes, cudaMemcpyDeviceToDevice, stream_);
 
   // Convert RGBA NHWC to float NCHW on GPU
   rgba_nhwc_to_nchw_gpu(

--- a/src/librediffusion.images.cpp
+++ b/src/librediffusion.images.cpp
@@ -128,19 +128,13 @@ void LibreDiffusionPipeline::rgba_resize(
   // 3. Choose Interpolation
   int eInterpolation = NPPI_INTER_LINEAR;
 
-  // NOTE: there used to be an unconditional `return;` right here — the resize had NEVER run. Any
-  // img2img whose input pixel count differed from the configured size was therefore processed from
-  // the UNINITIALISED VRAM of the VAE-sized staging buffer: measured on a 512px bundle, a 256x256
-  // frame came back pure black and byte-identical for two completely different inputs.
-  //
   // 5. Execute Resize
   NppStatus status = nppiResize_8u_C4R_Ctx(
       device_rgba_input_, nSrcStep, oSrcSize, oSrcRectROI, device_rgba_resized_,
       nDstStep, oDstSize, oDstRectROI, eInterpolation, this->npp_stream_);
 
-  // 6. Error Handling. A failed resize leaves the destination untouched, i.e. exactly the
-  // uninitialised-VRAM situation this function exists to prevent — so it must be an error, not a
-  // line on stderr.
+  // 6. Error Handling. A failed resize leaves the destination UNINITIALISED, so it cannot be
+  // downgraded to a warning.
   if(status != NPP_NO_ERROR)
   {
     throw std::runtime_error(
@@ -153,8 +147,7 @@ float*
 LibreDiffusionPipeline::img_preprocess(const uint8_t* device_rgba_input, int iw, int ih)
 {
   uint8_t* device_rgba_input_correct_size{};
-  // SHAPE, not area. This used to compare iw*ih against width*height, so 1024x256 was accepted as
-  // "already 512x512" and processed with the wrong strides — silently scrambled rather than resized.
+  // Shape, not area: 1024x256 has the same pixel count as 512x512 but different strides.
   if(iw == this->config_.width && ih == this->config_.height)
   {
     device_rgba_input_correct_size = device_rgba_input_->data();
@@ -167,9 +160,8 @@ LibreDiffusionPipeline::img_preprocess(const uint8_t* device_rgba_input, int iw,
     device_rgba_input_correct_size = device_rgba_input_vae_size_->data();
   }
 
-  // Exactly ONE frame reaches this buffer — img2img uploads one, rgba_resize writes one — while the
-  // conversion below and the VAE encoder both run config_.batch_size rows. Replicate it rather than
-  // hand rows 1..batch-1 to whatever the allocator last left in that VRAM.
+  // Exactly ONE frame reaches this buffer (img2img uploads one, rgba_resize writes one) while the
+  // conversion below and the VAE encoder both run config_.batch_size rows: replicate it.
   const size_t frame_bytes = (size_t)this->config_.width * this->config_.height * 4;
   for(int i = 1; i < this->config_.batch_size; i++)
     cudaMemcpyAsync(
@@ -194,7 +186,7 @@ LibreDiffusionPipeline::img_postprocess(__half* device_rgba_output, int iw, int 
       config_.height, stream_);
 
   uint8_t* device_rgba_output_correct_size{};
-  // SHAPE, not area (see img_preprocess).
+  // Shape, not area (see img_preprocess).
   if(iw == this->config_.width && ih == this->config_.height)
   {
     device_rgba_output_correct_size = device_rgba_output_vae_size_->data();

--- a/src/librediffusion.images.cpp
+++ b/src/librediffusion.images.cpp
@@ -1,7 +1,9 @@
 #include "librediffusion.hpp"
 #include "kernels.hpp"
 #include "nchw.hpp"
-#include "iostream"
+#include <iostream>
+#include <stdexcept>
+#include <string>
 
 namespace librediffusion
 {
@@ -126,17 +128,25 @@ void LibreDiffusionPipeline::rgba_resize(
   // 3. Choose Interpolation
   int eInterpolation = NPPI_INTER_LINEAR;
 
-  return;
+  // NOTE: there used to be an unconditional `return;` right here — the resize had NEVER run. Any
+  // img2img whose input pixel count differed from the configured size was therefore processed from
+  // the UNINITIALISED VRAM of the VAE-sized staging buffer: measured on a 512px bundle, a 256x256
+  // frame came back pure black and byte-identical for two completely different inputs.
+  //
   // 5. Execute Resize
   NppStatus status = nppiResize_8u_C4R_Ctx(
       device_rgba_input_, nSrcStep, oSrcSize, oSrcRectROI, device_rgba_resized_,
       nDstStep, oDstSize, oDstRectROI, eInterpolation, this->npp_stream_);
 
-  // 6. Error Handling
+  // 6. Error Handling. A failed resize leaves the destination untouched, i.e. exactly the
+  // uninitialised-VRAM situation this function exists to prevent — so it must be an error, not a
+  // line on stderr.
   if(status != NPP_NO_ERROR)
   {
-    std::cerr << "NPP Resize Error: " << status << std::endl;
-    // In production, handle this gracefully or throw
+    throw std::runtime_error(
+        "rgba_resize: nppiResize_8u_C4R_Ctx failed (NppStatus " + std::to_string((int)status)
+        + ") resizing " + std::to_string(iw) + "x" + std::to_string(ih) + " -> "
+        + std::to_string(ow) + "x" + std::to_string(oh));
   }
 }
 float*
@@ -144,7 +154,9 @@ LibreDiffusionPipeline::img_preprocess(const uint8_t* device_rgba_input, int iw,
 {
   // FIXME batch not handled
   uint8_t* device_rgba_input_correct_size{};
-  if((ih * iw) == (this->config_.height * this->config_.width))
+  // SHAPE, not area. This used to compare iw*ih against width*height, so 1024x256 was accepted as
+  // "already 512x512" and processed with the wrong strides — silently scrambled rather than resized.
+  if(iw == this->config_.width && ih == this->config_.height)
   {
     device_rgba_input_correct_size = device_rgba_input_->data();
   }
@@ -174,7 +186,8 @@ LibreDiffusionPipeline::img_postprocess(__half* device_rgba_output, int iw, int 
       config_.height, stream_);
 
   uint8_t* device_rgba_output_correct_size{};
-  if(ih * iw == this->config_.height * this->config_.width)
+  // SHAPE, not area (see img_preprocess).
+  if(iw == this->config_.width && ih == this->config_.height)
   {
     device_rgba_output_correct_size = device_rgba_output_vae_size_->data();
   }

--- a/src/librediffusion.img2img_turbo.cpp
+++ b/src/librediffusion.img2img_turbo.cpp
@@ -43,6 +43,23 @@ void bindOut(nvinfer1::IExecutionContext* c, const char* name, void* ptr)
   if(!c->setTensorAddress(name, ptr))
     throw std::runtime_error(std::string("img2img-turbo: setTensorAddress(out) failed: ") + name);
 }
+
+// getTensorShape() on a name the engine does not declare logs a TensorRT error and yields
+// nbDims < 0; look the name up first.
+nvinfer1::Dims io_shape(const nvinfer1::ICudaEngine* eng, const char* name)
+{
+  nvinfer1::Dims none{};
+  none.nbDims = -1;
+  if(!eng)
+    return none;
+  for(int i = 0; i < eng->getNbIOTensors(); i++)
+  {
+    const char* n = eng->getIOTensorName(i);
+    if(n && std::string(n) == name)
+      return eng->getTensorShape(name);
+  }
+  return none;
+}
 } // namespace
 
 Img2ImgTurboPipeline::Img2ImgTurboPipeline(const Img2ImgTurboEngines& p)
@@ -50,7 +67,37 @@ Img2ImgTurboPipeline::Img2ImgTurboPipeline(const Img2ImgTurboEngines& p)
   c_enc_ = makeContext(e_enc_, p.vae_encoder);
   c_unet_ = makeContext(e_unet_, p.unet);
   c_dec_ = makeContext(e_dec_, p.vae_decoder);
+  discoverGeometry();
   alloc();
+}
+
+// The buffer sizes the C-API publishes (frame_bytes / ehs_elements) must describe the ENGINES that
+// were actually loaded, not the 512x512 sd-turbo export this was first written against. Both come
+// out of statically-shaped inputs; anything dynamic or unrecognised keeps the historical default.
+void Img2ImgTurboPipeline::discoverGeometry()
+{
+  const nvinfer1::Dims img = io_shape(e_enc_->getEngine(), "image");
+  if(img.nbDims == 4 && img.d[2] > 0 && img.d[3] > 0)
+  {
+    // Every skip activation is H/1, H/2, H/4, H/8; a size the VAE cannot halve three times is not
+    // one this pipeline can drive.
+    if((img.d[2] % 8) != 0 || (img.d[3] % 8) != 0)
+      throw std::runtime_error(
+          "img2img-turbo: VAE encoder 'image' is " + std::to_string(img.d[2]) + "x"
+          + std::to_string(img.d[3]) + ", which is not a multiple of 8");
+    H_ = (int)img.d[2];
+    W_ = (int)img.d[3];
+    lh_ = H_ / 8;
+    lw_ = W_ / 8;
+  }
+
+  const nvinfer1::Dims ehs = io_shape(e_unet_->getEngine(), "ehs");
+  if(ehs.nbDims == 3 && ehs.d[1] > 0 && ehs.d[2] > 0)
+  {
+    ehs_seq_ = (int)ehs.d[1];
+    ehs_dim_ = (int)ehs.d[2];
+    ehs_elements_ = ehs_seq_ * ehs_dim_;
+  }
 }
 
 Img2ImgTurboPipeline::~Img2ImgTurboPipeline() = default;
@@ -68,7 +115,7 @@ void Img2ImgTurboPipeline::alloc()
   rgba_in_ = std::make_unique<CUDATensor<unsigned char>>((size_t)H_ * W_ * 4);
   rgba_out_ = std::make_unique<CUDATensor<unsigned char>>((size_t)H_ * W_ * 4);
   image_ = std::make_unique<CUDATensor<float>>((size_t)1 * 3 * H_ * W_);
-  ehs_ = std::make_unique<CUDATensor<float>>((size_t)1 * 77 * 1024);
+  ehs_ = std::make_unique<CUDATensor<float>>((size_t)ehs_elements_);
   out_ = std::make_unique<CUDATensor<float>>((size_t)1 * 3 * H_ * W_);
 }
 
@@ -91,7 +138,7 @@ void Img2ImgTurboPipeline::forward(const float* image, const float* ehs, float* 
   {
     auto* c = c_unet_.get();
     bindIn(c, "latent", latent_->data(), dims4(1, 4, lh_, lw_));
-    bindIn(c, "ehs", ehs, dims3(1, 77, 1024));
+    bindIn(c, "ehs", ehs, dims3(1, ehs_seq_, ehs_dim_));
     bindOut(c, "model_pred", model_pred_->data());
     if(!c->enqueueV3(stream))
       throw std::runtime_error("img2img-turbo: unet enqueueV3 failed");
@@ -134,7 +181,8 @@ void Img2ImgTurboPipeline::forward_rgba(
     const unsigned char* in_rgba, const float* ehs_host, unsigned char* out_rgba, cudaStream_t stream)
 {
   cudaMemcpyAsync(
-      ehs_->data(), ehs_host, (size_t)1 * 77 * 1024 * sizeof(float), cudaMemcpyHostToDevice, stream);
+      ehs_->data(), ehs_host, (size_t)ehs_elements_ * sizeof(float), cudaMemcpyHostToDevice,
+      stream);
   run_rgba(in_rgba, out_rgba, stream);
 }
 
@@ -142,7 +190,7 @@ void Img2ImgTurboPipeline::forward_rgba_dev(
     const unsigned char* in_rgba, const void* ehs_dev_fp16, unsigned char* out_rgba,
     cudaStream_t stream)
 {
-  launch_fp16_to_fp32(ehs_dev_fp16, ehs_->data(), 77 * 1024, stream);
+  launch_fp16_to_fp32(ehs_dev_fp16, ehs_->data(), ehs_elements_, stream);
   run_rgba(in_rgba, out_rgba, stream);
 }
 

--- a/src/librediffusion.img2img_turbo.hpp
+++ b/src/librediffusion.img2img_turbo.hpp
@@ -61,6 +61,13 @@ public:
       const unsigned char* in_rgba, const void* ehs_dev_fp16, unsigned char* out_rgba,
       cudaStream_t stream);
 
+  // The geometry the engines were built for. Callers of the host-bytes entry points need this to
+  // size their buffers (and the C API needs it to VALIDATE the sizes they declare).
+  int frameWidth() const { return W_; }
+  int frameHeight() const { return H_; }
+  // Elements the ehs buffer must contain: 1 * 77 * 1024 floats (SD2.1 cross-attention width).
+  static constexpr int kEhsElements = 77 * 1024;
+
   // sd-turbo scheduler alphas_cumprod[999] (the 1-step constant). Override if a model differs.
   // Clamp to (0,1] so the kernel's sqrtf(acp)/sqrtf(1-acp) can never hit a div-by-zero / NaN.
   void set_alpha_cumprod(float a) { acp_ = a < 1e-6f ? 1e-6f : (a > 1.0f ? 1.0f : a); }

--- a/src/librediffusion.img2img_turbo.hpp
+++ b/src/librediffusion.img2img_turbo.hpp
@@ -61,8 +61,7 @@ public:
       const unsigned char* in_rgba, const void* ehs_dev_fp16, unsigned char* out_rgba,
       cudaStream_t stream);
 
-  // The geometry the engines were built for. Callers of the host-bytes entry points need this to
-  // size their buffers (and the C API needs it to VALIDATE the sizes they declare).
+  // The geometry the engines were built for: callers of the host-bytes entry points size against it.
   int frameWidth() const { return W_; }
   int frameHeight() const { return H_; }
   // Elements the ehs buffer must contain: 1 * 77 * 1024 floats (SD2.1 cross-attention width).

--- a/src/librediffusion.img2img_turbo.hpp
+++ b/src/librediffusion.img2img_turbo.hpp
@@ -62,9 +62,12 @@ public:
       cudaStream_t stream);
 
   // The geometry the engines were built for: callers of the host-bytes entry points size against it.
+  // Read out of the loaded engines by discoverGeometry(); the constants below are only the fallback
+  // for an engine that declares a dynamic or unrecognised shape.
   int frameWidth() const { return W_; }
   int frameHeight() const { return H_; }
-  // Elements the ehs buffer must contain: 1 * 77 * 1024 floats (SD2.1 cross-attention width).
+  // Elements the ehs buffer must contain: the UNet's "ehs" input volume (1 * 77 * 1024 for SD2.1).
+  int ehsElements() const { return ehs_elements_; }
   static constexpr int kEhsElements = 77 * 1024;
 
   // sd-turbo scheduler alphas_cumprod[999] (the 1-step constant). Override if a model differs.
@@ -82,6 +85,8 @@ private:
 
   float acp_ = 0.00466009508818388f; // sd-turbo alphas_cumprod[999]
   int H_ = 512, W_ = 512, lh_ = 64, lw_ = 64;
+  int ehs_seq_ = 77, ehs_dim_ = 1024, ehs_elements_ = kEhsElements;
+  void discoverGeometry();
   void alloc();
   // shared body of forward_rgba / forward_rgba_dev (image upload+convert, forward, out download);
   // assumes ehs_ is already populated.

--- a/src/librediffusion.init.cpp
+++ b/src/librediffusion.init.cpp
@@ -4,6 +4,7 @@
 #include "nchw.hpp"
 #include "tensorrt_wrappers.hpp"
 
+#include <algorithm>
 #include <cmath>
 
 #include <cassert>
@@ -224,6 +225,12 @@ void LibreDiffusionPipeline::init_buffers()
   // When use_denoising_batch=true, we need noise for each timestep (denoising_steps), not batch_size
   int noise_batch_size
       = config_.use_denoising_batch ? config_.denoising_steps : config_.batch_size;
+  // ...but both buffers are READ at the latent extent: cfg-self and cfg-initialize copy
+  // `batch_size` latents out of stock_noise_, and add_noise reads `total_batch` out of init_noise_.
+  // Those match `denoising_steps` only when batch_size == denoising_steps * frame_buffer_size. On
+  // any other combination the copy ran off the end of the allocation — batch 2 at 1 step over-read a
+  // whole latent, which is the corruption the sweep saw surface at teardown.
+  noise_batch_size = std::max({noise_batch_size, config_.batch_size, timestep_extent()});
   init_noise_ = std::make_unique<CUDATensor<__half>>(
       noise_batch_size * 4 * config_.latent_height * config_.latent_width);
 

--- a/src/librediffusion.init.cpp
+++ b/src/librediffusion.init.cpp
@@ -41,10 +41,41 @@ void LibreDiffusionPipeline::init_cuda()
 
 void LibreDiffusionPipeline::init_engines()
 {
+  // FLUX.2-klein is a rectified-flow MMDiT with its own engines and its own C API
+  // (librediffusion_flux2_*). Declaring it here used to be "recorded for completeness": the SD
+  // pipeline ran, rendered ordinary SD frames, and reported success, so a host that mis-declared its
+  // model got a plausible image and no signal.
+  if(config_.model_type == ModelType::FLUX2_KLEIN_4B)
+    throw std::runtime_error(
+        "model_type FLUX2_KLEIN_4B is not a Stable Diffusion pipeline; drive klein through "
+        "librediffusion_flux2_stream_create");
+
   bool use_v2v = (config_.mode == PipelineMode::TEMPORAL_V2V);
   unet_ = std::make_unique<UNetWrapper>(config_.unet_engine_path, use_v2v);
   vae_encoder_ = std::make_unique<VAEEncoderWrapper>(config_.vae_encoder_path);
   vae_decoder_ = std::make_unique<VAEDecoderWrapper>(config_.vae_decoder_path);
+
+  // Same rule as ControlNet / IP-Adapter below: a mode the engine cannot honour is a configuration
+  // error, not a stderr line followed by plain img2img.
+  if(use_v2v && !(unet_->hasV2VKvo() || unet_->hasV2VOutputs()))
+    throw std::runtime_error(
+        "TEMPORAL_V2V requested but the UNet engine '" + config_.unet_engine_path
+        + "' is neither a kvo (kvo_cache_in_*) nor an attention_* StreamV2V UNet; export a v2v "
+          "UNet, or use MODE_SINGLE_FRAME");
+
+  // SDXL added conditioning (pooled text_embeds + time_ids) is an ENGINE property. Declaring it
+  // against an engine that has no text_embeds input made config_set_sdxl_config and
+  // prepare_sdxl_conditioning both return SUCCESS while the buffers went nowhere: the frame was
+  // byte-identical to not declaring it at all.
+  if(config_.model_type == ModelType::SDXL_TURBO && !unet_->hasSdxlConditioning())
+    throw std::runtime_error(
+        "model_type SDXL_TURBO but the UNet engine '" + config_.unet_engine_path
+        + "' declares no text_embeds/time_ids inputs; it is not an SDXL UNet");
+  if(config_.model_type != ModelType::SDXL_TURBO && unet_->hasSdxlConditioning())
+    throw std::runtime_error(
+        "the UNet engine '" + config_.unet_engine_path
+        + "' declares the SDXL text_embeds/time_ids inputs but model_type is not SDXL_TURBO; the "
+          "SD path never binds them");
 
   // ControlNet (optional, multi): create a wrapper per configured net. Enabled only when at least one
   // net is configured AND the UNet engine is control-aware (declares input_control_* inputs).

--- a/src/librediffusion.init.cpp
+++ b/src/librediffusion.init.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 
 #include <cassert>
 #include <chrono>
@@ -152,6 +153,27 @@ void LibreDiffusionPipeline::init_engines()
 
 void LibreDiffusionPipeline::init_buffers()
 {
+  // Every element count below is computed in int. width/height are bounded at the C API, but the
+  // batch counters are not bounded against the LATENT extent, and the products cross INT_MAX well
+  // before the counters look unreasonable: batch 128 at the maximum resolution already wraps.
+  // Signed overflow is UB and a wrapped count silently mis-sizes every buffer, so check the
+  // products themselves rather than guessing a bound for each factor.
+  {
+    const int64_t plane = (int64_t)4 * config_.latent_height * config_.latent_width;
+    const int64_t total_batch
+        = (int64_t)config_.batch_size
+          + (int64_t)(config_.denoising_steps - 1) * config_.frame_buffer_size;
+    const int64_t steps_batch
+        = (int64_t)config_.denoising_steps * config_.frame_buffer_size;
+    const int64_t worst = std::max({(int64_t)config_.batch_size, total_batch, steps_batch}) * plane;
+    if(worst > (int64_t)std::numeric_limits<int>::max())
+      throw invalid_dimensions_error(
+          "init_buffers: batch_size " + std::to_string(config_.batch_size) + " x "
+          + std::to_string(config_.denoising_steps) + " steps at "
+          + std::to_string(config_.latent_width) + "x" + std::to_string(config_.latent_height)
+          + " latent needs " + std::to_string(worst) + " elements, which does not fit in int");
+  }
+
   // Calculate sizes
   int latent_size
       = config_.batch_size * 4 * config_.latent_height * config_.latent_width;
@@ -340,9 +362,14 @@ std::string
 LibreDiffusionPipeline::geometry_rejection(const LibreDiffusionConfig& cfg) const
 {
   // The UNet is driven at unet_batch_size(); cfg-full doubles that, so this is the loosest bound and
-  // cannot refuse a geometry that would have worked.
-  const int unet_batch
-      = cfg.batch_size + (cfg.denoising_steps - 1) * cfg.frame_buffer_size;
+  // cannot refuse a geometry that would have worked. Widened: the guard's own arithmetic must not
+  // wrap on the values it exists to reject.
+  const int64_t unet_batch64
+      = (int64_t)cfg.batch_size + (int64_t)(cfg.denoising_steps - 1) * cfg.frame_buffer_size;
+  if(unet_batch64 > (int64_t)std::numeric_limits<int>::max())
+    return "batch_size " + std::to_string(cfg.batch_size) + " with "
+           + std::to_string(cfg.denoising_steps) + " denoising steps overflows the UNet batch";
+  const int unet_batch = (int)unet_batch64;
 
   if(vae_encoder_)
     if(auto why = vae_encoder_->rejectGeometry(cfg.batch_size, cfg.height, cfg.width);

--- a/src/librediffusion.init.cpp
+++ b/src/librediffusion.init.cpp
@@ -42,9 +42,7 @@ void LibreDiffusionPipeline::init_cuda()
 void LibreDiffusionPipeline::init_engines()
 {
   // FLUX.2-klein is a rectified-flow MMDiT with its own engines and its own C API
-  // (librediffusion_flux2_*). Declaring it here used to be "recorded for completeness": the SD
-  // pipeline ran, rendered ordinary SD frames, and reported success, so a host that mis-declared its
-  // model got a plausible image and no signal.
+  // (librediffusion_flux2_*); the SD pipeline cannot run it.
   if(config_.model_type == ModelType::FLUX2_KLEIN_4B)
     throw std::runtime_error(
         "model_type FLUX2_KLEIN_4B is not a Stable Diffusion pipeline; drive klein through "
@@ -55,18 +53,15 @@ void LibreDiffusionPipeline::init_engines()
   vae_encoder_ = std::make_unique<VAEEncoderWrapper>(config_.vae_encoder_path);
   vae_decoder_ = std::make_unique<VAEDecoderWrapper>(config_.vae_decoder_path);
 
-  // Same rule as ControlNet / IP-Adapter below: a mode the engine cannot honour is a configuration
-  // error, not a stderr line followed by plain img2img.
+  // A mode the engine cannot honour is a configuration error.
   if(use_v2v && !(unet_->hasV2VKvo() || unet_->hasV2VOutputs()))
     throw std::runtime_error(
         "TEMPORAL_V2V requested but the UNet engine '" + config_.unet_engine_path
         + "' is neither a kvo (kvo_cache_in_*) nor an attention_* StreamV2V UNet; export a v2v "
           "UNet, or use MODE_SINGLE_FRAME");
 
-  // SDXL added conditioning (pooled text_embeds + time_ids) is an ENGINE property. Declaring it
-  // against an engine that has no text_embeds input made config_set_sdxl_config and
-  // prepare_sdxl_conditioning both return SUCCESS while the buffers went nowhere: the frame was
-  // byte-identical to not declaring it at all.
+  // SDXL added conditioning (pooled text_embeds + time_ids) is an ENGINE property: model_type and
+  // the engine must agree, or the buffers are prepared and then bound nowhere.
   if(config_.model_type == ModelType::SDXL_TURBO && !unet_->hasSdxlConditioning())
     throw std::runtime_error(
         "model_type SDXL_TURBO but the UNet engine '" + config_.unet_engine_path
@@ -89,11 +84,6 @@ void LibreDiffusionPipeline::init_engines()
   {
     if(!unet_->hasControlInputs())
     {
-      // L-15: this used to print a warning to STDOUT, disable ControlNet, and carry on rendering
-      // ordinary frames — statistically identical to the plain model's — while the host believed its
-      // control image was steering the output. The C API reported success throughout; the only hint
-      // was set_controlnet_cond_rgba later returning -99 for an index that no longer existed.
-      // A feature the bundle cannot honour is a configuration error, not a footnote.
       throw std::runtime_error(
           std::to_string(config_.controlnets.size())
           + " ControlNet(s) configured but the UNet engine '" + config_.unet_engine_path
@@ -116,9 +106,6 @@ void LibreDiffusionPipeline::init_engines()
   // tokens are fed host-side via set_ipadapter_tokens; default the per-layer scale vector to a uniform
   // config_.ipadapter_scale (length = the engine's num_ip_layers).
   ipadapter_enabled_ = unet_->hasIpAdapter();
-  // L-15, second half — and the quieter one: an IP-Adapter configured against a plain UNet gave the
-  // host NO signal at all. set_ipadapter_tokens returned SUCCESS, inference returned SUCCESS, and
-  // the frame was identical to the one the plain model would have produced.
   if(config_.ipadapter_requested && !ipadapter_enabled_)
   {
     throw std::runtime_error(
@@ -256,11 +243,9 @@ void LibreDiffusionPipeline::init_buffers()
   // When use_denoising_batch=true, we need noise for each timestep (denoising_steps), not batch_size
   int noise_batch_size
       = config_.use_denoising_batch ? config_.denoising_steps : config_.batch_size;
-  // ...but both buffers are READ at the latent extent: cfg-self and cfg-initialize copy
-  // `batch_size` latents out of stock_noise_, and add_noise reads `total_batch` out of init_noise_.
-  // Those match `denoising_steps` only when batch_size == denoising_steps * frame_buffer_size. On
-  // any other combination the copy ran off the end of the allocation — batch 2 at 1 step over-read a
-  // whole latent, which is the corruption the sweep saw surface at teardown.
+  // ...but both buffers are READ at the latent extent: cfg-self/cfg-initialize copy `batch_size`
+  // latents out of stock_noise_ and add_noise reads `total_batch` out of init_noise_, which match
+  // `denoising_steps` only when batch_size == denoising_steps * frame_buffer_size.
   noise_batch_size = std::max({noise_batch_size, config_.batch_size, timestep_extent()});
   init_noise_ = std::make_unique<CUDATensor<__half>>(
       noise_batch_size * 4 * config_.latent_height * config_.latent_width);
@@ -326,10 +311,6 @@ void LibreDiffusionPipeline::init_buffers()
 
 void LibreDiffusionPipeline::init_npp()
 {
-  // This used to declare a LOCAL `NppStreamContext npp_stream_;` that shadowed the member of the
-  // same name: everything below filled the local, the member stayed uninitialised, and the local was
-  // discarded on return. It was harmless only because its sole consumer — rgba_resize — began with
-  // an unconditional `return;` and never ran. Now that the resize is live, the member must be real.
   npp_stream_ = NppStreamContext{};
 
   int device = config_.device;
@@ -381,9 +362,7 @@ LibreDiffusionPipeline::geometry_rejection(const LibreDiffusionConfig& cfg) cons
 
 void LibreDiffusionPipeline::reinit_buffers(const LibreDiffusionConfig& new_config)
 {
-  // F-07's rule at the seam F-07's fix did not cover: engines cannot be reloaded here, so a geometry
-  // outside their profiles used to be installed, reported as success, and refused by TensorRT one
-  // call later as an opaque INTERNAL error from img2img.
+  // Engines cannot be reloaded here, so a geometry outside their profiles is unusable.
   if(auto why = geometry_rejection(new_config); !why.empty())
     throw std::invalid_argument("reinit_buffers: " + why);
 
@@ -414,10 +393,8 @@ void LibreDiffusionPipeline::reinit_buffers(const LibreDiffusionConfig& new_conf
   config_.use_feature_injection = new_config.use_feature_injection;
   config_.feature_injection_strength = new_config.feature_injection_strength;
   config_.feature_similarity_threshold = new_config.feature_similarity_threshold;
-  // reinit_buffers takes a whole config from the host: sanitize the two values that are fatal
-  // rather than merely wrong (0 -> SIGFPE in the img2img modulo; negative maxframes -> SIZE_MAX,
-  // i.e. an unbounded per-frame VRAM leak). The C-API setters reject them; a config that reached
-  // here another way is clamped rather than installed.
+  // Clamp the two values that are fatal rather than merely wrong: 0 is a SIGFPE in the img2img
+  // modulo, a negative maxframes reads as SIZE_MAX (the deque never evicts).
   config_.cache_interval = new_config.cache_interval >= 1 ? new_config.cache_interval : 1;
   config_.cache_maxframes = new_config.cache_maxframes >= 1 ? new_config.cache_maxframes : 1;
   config_.use_tome_cache = new_config.use_tome_cache;

--- a/src/librediffusion.init.cpp
+++ b/src/librediffusion.init.cpp
@@ -364,7 +364,7 @@ void LibreDiffusionPipeline::reinit_buffers(const LibreDiffusionConfig& new_conf
 {
   // Engines cannot be reloaded here, so a geometry outside their profiles is unusable.
   if(auto why = geometry_rejection(new_config); !why.empty())
-    throw std::invalid_argument("reinit_buffers: " + why);
+    throw invalid_dimensions_error("reinit_buffers: " + why);
 
   // Preserve engine paths and mode (these cannot change without engine reload)
   // But update all other parameters

--- a/src/librediffusion.init.cpp
+++ b/src/librediffusion.init.cpp
@@ -353,8 +353,40 @@ void LibreDiffusionPipeline::init_npp()
     npp_stream_.nStreamFlags = 0;
 }
 
+std::string
+LibreDiffusionPipeline::geometry_rejection(const LibreDiffusionConfig& cfg) const
+{
+  // The UNet is driven at unet_batch_size(); cfg-full doubles that, so this is the loosest bound and
+  // cannot refuse a geometry that would have worked.
+  const int unet_batch
+      = cfg.batch_size + (cfg.denoising_steps - 1) * cfg.frame_buffer_size;
+
+  if(vae_encoder_)
+    if(auto why = vae_encoder_->rejectGeometry(cfg.batch_size, cfg.height, cfg.width);
+       !why.empty())
+      return why;
+  if(vae_decoder_)
+    if(auto why = vae_decoder_->rejectGeometry(
+           cfg.batch_size, cfg.latent_height, cfg.latent_width);
+       !why.empty())
+      return why;
+  if(unet_)
+    if(auto why = unet_->rejectGeometry(
+           unet_batch, cfg.latent_height, cfg.latent_width, cfg.text_seq_len,
+           cfg.text_hidden_dim);
+       !why.empty())
+      return why;
+  return {};
+}
+
 void LibreDiffusionPipeline::reinit_buffers(const LibreDiffusionConfig& new_config)
 {
+  // F-07's rule at the seam F-07's fix did not cover: engines cannot be reloaded here, so a geometry
+  // outside their profiles used to be installed, reported as success, and refused by TensorRT one
+  // call later as an opaque INTERNAL error from img2img.
+  if(auto why = geometry_rejection(new_config); !why.empty())
+    throw std::invalid_argument("reinit_buffers: " + why);
+
   // Preserve engine paths and mode (these cannot change without engine reload)
   // But update all other parameters
   config_.width = new_config.width;

--- a/src/librediffusion.init.cpp
+++ b/src/librediffusion.init.cpp
@@ -246,6 +246,8 @@ void LibreDiffusionPipeline::init_buffers()
   // ...but both buffers are READ at the latent extent: cfg-self/cfg-initialize copy `batch_size`
   // latents out of stock_noise_ and add_noise reads `total_batch` out of init_noise_, which match
   // `denoising_steps` only when batch_size == denoising_steps * frame_buffer_size.
+  init_noise_input_elems_
+      = (size_t)noise_batch_size * 4 * config_.latent_height * config_.latent_width;
   noise_batch_size = std::max({noise_batch_size, config_.batch_size, timestep_extent()});
   init_noise_ = std::make_unique<CUDATensor<__half>>(
       noise_batch_size * 4 * config_.latent_height * config_.latent_width);

--- a/src/librediffusion.init.cpp
+++ b/src/librediffusion.init.cpp
@@ -57,9 +57,16 @@ void LibreDiffusionPipeline::init_engines()
   {
     if(!unet_->hasControlInputs())
     {
-      std::cout << "Warning: " << config_.controlnets.size() << " controlnet(s) configured but the UNet "
-                   "engine has no input_control_* inputs; ControlNet DISABLED (use a control-aware "
-                   "unet.engine)" << std::endl;
+      // L-15: this used to print a warning to STDOUT, disable ControlNet, and carry on rendering
+      // ordinary frames — statistically identical to the plain model's — while the host believed its
+      // control image was steering the output. The C API reported success throughout; the only hint
+      // was set_controlnet_cond_rgba later returning -99 for an index that no longer existed.
+      // A feature the bundle cannot honour is a configuration error, not a footnote.
+      throw std::runtime_error(
+          std::to_string(config_.controlnets.size())
+          + " ControlNet(s) configured but the UNet engine '" + config_.unet_engine_path
+          + "' has no input_control_* inputs; use a control-aware unet.engine, or do not configure "
+            "ControlNet");
     }
     else
     {
@@ -77,6 +84,16 @@ void LibreDiffusionPipeline::init_engines()
   // tokens are fed host-side via set_ipadapter_tokens; default the per-layer scale vector to a uniform
   // config_.ipadapter_scale (length = the engine's num_ip_layers).
   ipadapter_enabled_ = unet_->hasIpAdapter();
+  // L-15, second half — and the quieter one: an IP-Adapter configured against a plain UNet gave the
+  // host NO signal at all. set_ipadapter_tokens returned SUCCESS, inference returned SUCCESS, and
+  // the frame was identical to the one the plain model would have produced.
+  if(config_.ipadapter_requested && !ipadapter_enabled_)
+  {
+    throw std::runtime_error(
+        "IP-Adapter configured but the UNet engine '" + config_.unet_engine_path
+        + "' is not an IP variant (no ipadapter_scale input); use an IP-Adapter unet.engine, or do "
+          "not configure IP-Adapter");
+  }
   if(ipadapter_enabled_)
   {
     int n = unet_->numIpLayers();

--- a/src/librediffusion.init.cpp
+++ b/src/librediffusion.init.cpp
@@ -271,7 +271,11 @@ void LibreDiffusionPipeline::init_buffers()
 
 void LibreDiffusionPipeline::init_npp()
 {
-  NppStreamContext npp_stream_;
+  // This used to declare a LOCAL `NppStreamContext npp_stream_;` that shadowed the member of the
+  // same name: everything below filled the local, the member stayed uninitialised, and the local was
+  // discarded on return. It was harmless only because its sole consumer — rgba_resize — began with
+  // an unconditional `return;` and never ran. Now that the resize is live, the member must be real.
+  npp_stream_ = NppStreamContext{};
 
   int device = config_.device;
   cudaGetDevice(&device);
@@ -287,6 +291,11 @@ void LibreDiffusionPipeline::init_npp()
   npp_stream_.nCudaDevAttrComputeCapabilityMajor = prop.major;
   npp_stream_.nCudaDevAttrComputeCapabilityMinor = prop.minor;
   npp_stream_.hStream = this->stream_;
+  unsigned int flags = 0;
+  if(this->stream_ && cudaStreamGetFlags(this->stream_, &flags) == cudaSuccess)
+    npp_stream_.nStreamFlags = flags;
+  else
+    npp_stream_.nStreamFlags = 0;
 }
 
 void LibreDiffusionPipeline::reinit_buffers(const LibreDiffusionConfig& new_config)

--- a/src/librediffusion.init.cpp
+++ b/src/librediffusion.init.cpp
@@ -318,8 +318,12 @@ void LibreDiffusionPipeline::reinit_buffers(const LibreDiffusionConfig& new_conf
   config_.use_feature_injection = new_config.use_feature_injection;
   config_.feature_injection_strength = new_config.feature_injection_strength;
   config_.feature_similarity_threshold = new_config.feature_similarity_threshold;
-  config_.cache_interval = new_config.cache_interval;
-  config_.cache_maxframes = new_config.cache_maxframes;
+  // reinit_buffers takes a whole config from the host: sanitize the two values that are fatal
+  // rather than merely wrong (0 -> SIGFPE in the img2img modulo; negative maxframes -> SIZE_MAX,
+  // i.e. an unbounded per-frame VRAM leak). The C-API setters reject them; a config that reached
+  // here another way is clamped rather than installed.
+  config_.cache_interval = new_config.cache_interval >= 1 ? new_config.cache_interval : 1;
+  config_.cache_maxframes = new_config.cache_maxframes >= 1 ? new_config.cache_maxframes : 1;
   config_.use_tome_cache = new_config.use_tome_cache;
   config_.tome_ratio = new_config.tome_ratio;
   config_.use_cuda_graph = new_config.use_cuda_graph;

--- a/src/librediffusion.unet.cpp
+++ b/src/librediffusion.unet.cpp
@@ -142,6 +142,17 @@ void LibreDiffusionPipeline::scheduler_step_batch(
         + " (denoising_steps=" + std::to_string(config_.denoising_steps) + ")");
   }
 
+  // N is the element count the caller wants stepped; the kernel takes it as batch x 4 x H x W. It was
+  // hardcoded to a single row, so at batch_size > 1 every row but the first came back unwritten and
+  // the store_d2d that follows read uninitialised VRAM. Callers that step one row at a time pass
+  // exactly `stride` and are unaffected.
+  const int stride = 4 * config_.latent_height * config_.latent_width;
+  if(stride <= 0 || N <= 0 || N % stride != 0)
+    throw std::runtime_error(
+        "scheduler_step_batch: element count " + std::to_string(N)
+        + " is not a whole number of 4x" + std::to_string(config_.latent_height) + "x"
+        + std::to_string(config_.latent_width) + " latents");
+
   // Access host-side copies (safe for CPU access)
   float alpha = alpha_at(idx);
   float beta = beta_at(idx);
@@ -150,8 +161,8 @@ void LibreDiffusionPipeline::scheduler_step_batch(
 
   launch_scheduler_step_fp16(
       model_pred, x_t_latent, denoised_out, alpha, beta, c_skip, c_out,
-      1, // FIXME double-check that batch size is 1 in this case by comparing with the python version
-      4, // channels
+      N / stride, // rows
+      4,          // channels
       config_.latent_height, config_.latent_width, stream);
 }
 

--- a/src/librediffusion.unet.cpp
+++ b/src/librediffusion.unet.cpp
@@ -107,8 +107,8 @@ void LibreDiffusionPipeline::add_noise(
     int t_index, int N, cudaStream_t stream)
 {
   // Access host-side copies (safe for CPU access)
-  float alpha = alpha_prod_t_sqrt_host_[t_index];
-  float beta = beta_prod_t_sqrt_host_[t_index];
+  float alpha = alpha_at(t_index);
+  float beta = beta_at(t_index);
 
   launch_add_noise_fp16(original_samples, noise, noisy_samples, alpha, beta, N, stream);
 }
@@ -143,10 +143,10 @@ void LibreDiffusionPipeline::scheduler_step_batch(
   }
 
   // Access host-side copies (safe for CPU access)
-  float alpha = alpha_prod_t_sqrt_host_[idx];
-  float beta = beta_prod_t_sqrt_host_[idx];
-  float c_skip = c_skip_host_[idx];
-  float c_out = c_out_host_[idx];
+  float alpha = alpha_at(idx);
+  float beta = beta_at(idx);
+  float c_skip = c_skip_at(idx);
+  float c_out = c_out_at(idx);
 
   launch_scheduler_step_fp16(
       model_pred, x_t_latent, denoised_out, alpha, beta, c_skip, c_out,
@@ -646,7 +646,10 @@ void LibreDiffusionPipeline::predict_x0_batch_impl_multi_step_batched(
     // Stride is for ONE latent (one image at one timestep)
     int stride = 1 * 4 * config_.latent_height * config_.latent_width;
     int single_size = total_batch * 4 * config_.latent_height * config_.latent_width;
-    for(int i = 0; i < config_.denoising_steps; i++)
+    // Bound the scheduler loop by the coefficients we actually HAVE, not by the declared step count
+    // (L-16). prepare_scheduler now refuses a disagreeing length, so this is the same number; it
+    // stays correct-by-construction if the two ever drift again.
+    for(int i = 0; i < denoise_steps(); i++)
     {
       int offset = i * stride;
       scheduler_step_batch(
@@ -669,14 +672,14 @@ void LibreDiffusionPipeline::predict_x0_batch_impl_multi_step_batched(
     //       stock_noise = init_noise + delta_x
     if(config_.guidance_scale > 1.0f && (config_.cfg_type == 2 || config_.cfg_type == 3))
     {
-      int batch_size = config_.denoising_steps;  // Number of timesteps
+      int batch_size = denoise_steps();  // Number of timesteps (bounded by the schedule length)
 
       // scaled_noise = beta * stock_noise
       CUDATensor<__half> scaled_noise(single_size);
       for(int i = 0; i < batch_size; i++)
       {
         int offset = i * stride;
-        float beta = beta_prod_t_sqrt_host_[i];
+        float beta = beta_at(i);
         // Copy and scale: scaled_noise[i] = beta[i] * stock_noise[i]
         cudaMemcpyAsync(
             scaled_noise.data() + offset, stock_noise_->data() + offset,
@@ -700,8 +703,8 @@ void LibreDiffusionPipeline::predict_x0_batch_impl_multi_step_batched(
       for(int i = 0; i < batch_size; i++)
       {
         int offset = i * stride;
-        float alpha_next = (i < batch_size - 1) ? alpha_prod_t_sqrt_host_[i + 1] : 1.0f;
-        float beta_next = (i < batch_size - 1) ? beta_prod_t_sqrt_host_[i + 1] : 1.0f;
+        float alpha_next = (i < batch_size - 1) ? alpha_at(i + 1) : 1.0f;
+        float beta_next = (i < batch_size - 1) ? beta_at(i + 1) : 1.0f;
         float scale = alpha_next / beta_next;
         launch_scalar_mul_inplace_fp16(delta_x.data() + offset, scale, stride, stream);
       }
@@ -753,7 +756,7 @@ void LibreDiffusionPipeline::predict_x0_batch_impl_multi_step_batched(
 
         // DEBUG: Check what we're putting into the buffer update
         // FIXME this does not look like the correct thing ?
-        for(int i = 0; i < config_.denoising_steps - 1; i++)
+        for(int i = 0; i < denoise_steps() - 1; i++)
         {
           int denoised_offset = i * stride;    // denoised[i]
           int noise_offset = (i + 1) * stride; // noise[i+1]
@@ -774,11 +777,11 @@ void LibreDiffusionPipeline::predict_x0_batch_impl_multi_step_batched(
         // this raw-copied denoised[:-1] (omitting alpha<1), inflating the streaming buffer by
         // ~1/alpha and drifting the converged x0 magnitude ~5% high (validation harness:
         // cfg-none noise-0 predict_x0 rel 0.053, norm 146 vs golden 139).
-        for(int i = 0; i < config_.denoising_steps - 1; i++)
+        for(int i = 0; i < denoise_steps() - 1; i++)
         {
           int denoised_offset = i * stride; // denoised[i] = x_0_pred[i]
           int buffer_offset = i * stride;   // buffer[i]
-          float alpha_next = alpha_prod_t_sqrt_host_[i + 1]; // alpha[i+1]
+          float alpha_next = alpha_at(i + 1); // alpha[i+1]
           cudaMemcpyAsync(
               x_t_latent_buffer_->data() + buffer_offset, denoised.data() + denoised_offset,
               stride * sizeof(__half), cudaMemcpyDeviceToDevice, stream);
@@ -930,7 +933,8 @@ void LibreDiffusionPipeline::predict_x0_batch_impl_multi_step_sequential(
   CUDATensor<__half> current_latent(latent_size);
   current_latent.load_d2d(x_t_latent.data(), latent_size, stream);
 
-  for(int idx = 0; idx < config_.denoising_steps; idx++)
+  // Bounded by the schedule length, not the declared step count (L-16).
+  for(int idx = 0; idx < denoise_steps(); idx++)
   {
     // Prepare UNet inputs for this timestep
     std::unique_ptr<CUDATensor<__half>> unet_input_latent;
@@ -1267,7 +1271,7 @@ void LibreDiffusionPipeline::predict_x0_batch_impl_multi_step_sequential(
     if(config_.guidance_scale > 1.0f && (config_.cfg_type == 2 || config_.cfg_type == 3))
     {
       int stride = latent_size;
-      float beta = beta_prod_t_sqrt_host_[idx];
+      float beta = beta_at(idx);
 
       // scaled_noise = beta * stock_noise
       CUDATensor<__half> scaled_noise(stride);
@@ -1283,8 +1287,8 @@ void LibreDiffusionPipeline::predict_x0_batch_impl_multi_step_sequential(
           delta_x.data(), idx, stride, stream);
 
       // delta_x = alpha_next * delta_x / beta_next
-      float alpha_next = (idx < config_.denoising_steps - 1) ? alpha_prod_t_sqrt_host_[idx + 1] : 1.0f;
-      float beta_next = (idx < config_.denoising_steps - 1) ? beta_prod_t_sqrt_host_[idx + 1] : 1.0f;
+      float alpha_next = (idx < denoise_steps() - 1) ? alpha_at(idx + 1) : 1.0f;
+      float beta_next = (idx < denoise_steps() - 1) ? beta_at(idx + 1) : 1.0f;
       float scale = alpha_next / beta_next;
       launch_scalar_mul_inplace_fp16(delta_x.data(), scale, stride, stream);
 
@@ -1300,7 +1304,7 @@ void LibreDiffusionPipeline::predict_x0_batch_impl_multi_step_sequential(
     }
 
     // If not the last timestep, prepare noisy latent for next iteration
-    if(idx < config_.denoising_steps - 1)
+    if(idx < denoise_steps() - 1)
     {
       if(config_.do_add_noise)
       {
@@ -1323,7 +1327,7 @@ void LibreDiffusionPipeline::predict_x0_batch_impl_multi_step_sequential(
         // No noise: just scale with alpha
         // current_latent = alpha[idx+1] * x_0_pred
         int next_t_idx = idx + 1;
-        float alpha = alpha_prod_t_sqrt_host_[next_t_idx];
+        float alpha = alpha_at(next_t_idx);
 
         // Copy and scale x_0_pred by alpha
         current_latent.load_d2d(x_0_pred_step.data(), latent_size, stream);

--- a/src/librediffusion.unet.cpp
+++ b/src/librediffusion.unet.cpp
@@ -749,18 +749,7 @@ void LibreDiffusionPipeline::predict_x0_batch_impl_multi_step_batched(
 
       if(config_.do_add_noise)
       {
-        // Need to add noise: buffer = alpha * denoised + beta * noise
-        // Python: self.x_t_latent_buffer = alpha[1:] * x_0_pred[:-1] + beta[1:] * noise[1:]
-        // This means: buffer[i] = alpha[i+1] * denoised[i] + beta[i+1] * noise[i+1]
-        // For denoising_steps=2: buffer[0] = alpha[1] * denoised[0] + beta[1] * noise[1]
-
-        // WAIT - re-reading Python code more carefully:
-        // x_0_pred[:-1] means "all but the last", so denoised[0:denoising_steps-1]
-        // noise[1:] means "skip first", so noise[1:denoising_steps]
-        // alpha[1:] means "skip first", so alpha[1:denoising_steps]
-
-        // DEBUG: Check what we're putting into the buffer update
-        // FIXME this does not look like the correct thing ?
+        // buffer[i] = alpha[i+1] * denoised[i] + beta[i+1] * noise[i+1]
         for(int i = 0; i < denoise_steps() - 1; i++)
         {
           int denoised_offset = i * stride;    // denoised[i]
@@ -775,13 +764,8 @@ void LibreDiffusionPipeline::predict_x0_batch_impl_multi_step_batched(
       }
       else
       {
-        // No noise: buffer[i] = alpha[i+1] * denoised[i]  (beta*noise term is 0).
-        // Python (do_add_noise=False): x_t_latent_buffer = alpha_prod_t_sqrt[1:] * x_0_pred[:-1].
-        // The alpha scaling is NOT baked into the scheduler step output (denoised here IS
-        // x_0_pred, the clean prediction), so we must apply alpha[i+1] explicitly. Previously
-        // this raw-copied denoised[:-1] (omitting alpha<1), inflating the streaming buffer by
-        // ~1/alpha and drifting the converged x0 magnitude ~5% high (validation harness:
-        // cfg-none noise-0 predict_x0 rel 0.053, norm 146 vs golden 139).
+        // buffer[i] = alpha[i+1] * denoised[i]. `denoised` is x_0_pred, so the alpha scaling is not
+        // already applied and must be explicit.
         for(int i = 0; i < denoise_steps() - 1; i++)
         {
           int denoised_offset = i * stride; // denoised[i] = x_0_pred[i]

--- a/src/librediffusion.unet.cpp
+++ b/src/librediffusion.unet.cpp
@@ -142,10 +142,7 @@ void LibreDiffusionPipeline::scheduler_step_batch(
         + " (denoising_steps=" + std::to_string(config_.denoising_steps) + ")");
   }
 
-  // N is the element count the caller wants stepped; the kernel takes it as batch x 4 x H x W. It was
-  // hardcoded to a single row, so at batch_size > 1 every row but the first came back unwritten and
-  // the store_d2d that follows read uninitialised VRAM. Callers that step one row at a time pass
-  // exactly `stride` and are unaffected.
+  // N is the element count the caller wants stepped; the kernel takes it as batch x 4 x H x W.
   const int stride = 4 * config_.latent_height * config_.latent_width;
   if(stride <= 0 || N <= 0 || N % stride != 0)
     throw std::runtime_error(
@@ -657,9 +654,6 @@ void LibreDiffusionPipeline::predict_x0_batch_impl_multi_step_batched(
     // Stride is for ONE latent (one image at one timestep)
     int stride = 1 * 4 * config_.latent_height * config_.latent_width;
     int single_size = total_batch * 4 * config_.latent_height * config_.latent_width;
-    // Bound the scheduler loop by the coefficients we actually HAVE, not by the declared step count
-    // (L-16). prepare_scheduler now refuses a disagreeing length, so this is the same number; it
-    // stays correct-by-construction if the two ever drift again.
     for(int i = 0; i < denoise_steps(); i++)
     {
       int offset = i * stride;
@@ -683,7 +677,7 @@ void LibreDiffusionPipeline::predict_x0_batch_impl_multi_step_batched(
     //       stock_noise = init_noise + delta_x
     if(config_.guidance_scale > 1.0f && (config_.cfg_type == 2 || config_.cfg_type == 3))
     {
-      int batch_size = denoise_steps();  // Number of timesteps (bounded by the schedule length)
+      int batch_size = denoise_steps();  // Number of timesteps
 
       // scaled_noise = beta * stock_noise
       CUDATensor<__half> scaled_noise(single_size);
@@ -944,7 +938,6 @@ void LibreDiffusionPipeline::predict_x0_batch_impl_multi_step_sequential(
   CUDATensor<__half> current_latent(latent_size);
   current_latent.load_d2d(x_t_latent.data(), latent_size, stream);
 
-  // Bounded by the schedule length, not the declared step count (L-16).
   for(int idx = 0; idx < denoise_steps(); idx++)
   {
     // Prepare UNet inputs for this timestep

--- a/src/librediffusion.v2v.cpp
+++ b/src/librediffusion.v2v.cpp
@@ -32,6 +32,15 @@ void LibreDiffusionPipeline::enableTemporalCoherence(
   if(max_cached_frames < 1)
     throw std::invalid_argument("enableTemporalCoherence: max_cached_frames must be >= 1");
 
+  // L-15's shape, in the corner L-15 did not cover: on an engine that is neither a kvo nor a legacy
+  // attention_* StreamV2V UNet this returned SUCCESS, printed a line to stderr, and rendered frames
+  // byte-identical to plain img2img. A feature the bundle cannot honour is an error.
+  if(!unet_ || !(unet_->hasV2VKvo() || unet_->hasV2VOutputs()))
+    throw std::runtime_error(
+        "enableTemporalCoherence: the UNet engine '" + config_.unet_engine_path
+        + "' is neither a kvo (kvo_cache_in_*) nor an attention_* StreamV2V UNet, so temporal "
+          "coherence cannot be applied; export a v2v UNet or stay in single-frame mode");
+
   config_.mode = PipelineMode::TEMPORAL_V2V;
   config_.use_feature_injection = use_feature_injection;
   config_.feature_injection_strength = injection_strength;

--- a/src/librediffusion.v2v.cpp
+++ b/src/librediffusion.v2v.cpp
@@ -22,19 +22,14 @@ void LibreDiffusionPipeline::enableTemporalCoherence(
     bool use_feature_injection, float injection_strength, float similarity_threshold,
     int cache_interval, int max_cached_frames)
 {
-  // Last line of defence for the two values that are not merely wrong but fatal: cache_interval is
-  // the divisor of `frame_id % cache_interval` in img2img_impl (0 -> SIGFPE, uncatchable), and
-  // cache_maxframes is compared against a size_t (negative -> SIZE_MAX -> the deque never evicts and
-  // VRAM grows by one latent per frame). The C API rejects both; refuse here too so no internal
-  // caller can install them.
+  // cache_interval is the divisor of `frame_id % cache_interval` in img2img_impl (0 -> SIGFPE), and
+  // max_cached_frames is compared against a size_t (negative -> SIZE_MAX -> the deque never evicts).
   if(cache_interval < 1)
     throw std::invalid_argument("enableTemporalCoherence: cache_interval must be >= 1");
   if(max_cached_frames < 1)
     throw std::invalid_argument("enableTemporalCoherence: max_cached_frames must be >= 1");
 
-  // L-15's shape, in the corner L-15 did not cover: on an engine that is neither a kvo nor a legacy
-  // attention_* StreamV2V UNet this returned SUCCESS, printed a line to stderr, and rendered frames
-  // byte-identical to plain img2img. A feature the bundle cannot honour is an error.
+  // A feature the bundle cannot honour is an error, not a stderr line followed by plain img2img.
   if(!unet_ || !(unet_->hasV2VKvo() || unet_->hasV2VOutputs()))
     throw std::runtime_error(
         "enableTemporalCoherence: the UNet engine '" + config_.unet_engine_path

--- a/src/librediffusion.v2v.cpp
+++ b/src/librediffusion.v2v.cpp
@@ -2,6 +2,8 @@
 
 #include "tensorrt_wrappers.hpp"
 
+#include <stdexcept>
+
 namespace librediffusion
 {
 
@@ -20,6 +22,16 @@ void LibreDiffusionPipeline::enableTemporalCoherence(
     bool use_feature_injection, float injection_strength, float similarity_threshold,
     int cache_interval, int max_cached_frames)
 {
+  // Last line of defence for the two values that are not merely wrong but fatal: cache_interval is
+  // the divisor of `frame_id % cache_interval` in img2img_impl (0 -> SIGFPE, uncatchable), and
+  // cache_maxframes is compared against a size_t (negative -> SIZE_MAX -> the deque never evicts and
+  // VRAM grows by one latent per frame). The C API rejects both; refuse here too so no internal
+  // caller can install them.
+  if(cache_interval < 1)
+    throw std::invalid_argument("enableTemporalCoherence: cache_interval must be >= 1");
+  if(max_cached_frames < 1)
+    throw std::invalid_argument("enableTemporalCoherence: max_cached_frames must be >= 1");
+
   config_.mode = PipelineMode::TEMPORAL_V2V;
   config_.use_feature_injection = use_feature_injection;
   config_.feature_injection_strength = injection_strength;

--- a/src/librediffusion.vae.cpp
+++ b/src/librediffusion.vae.cpp
@@ -10,8 +10,8 @@ void LibreDiffusionPipeline::add_noise_direct(
     cudaStream_t stream)
 {
   // Access host-side copies 
-  float alpha = alpha_prod_t_sqrt_host_[t_index];
-  float beta = beta_prod_t_sqrt_host_[t_index];
+  float alpha = alpha_at(t_index);
+  float beta = beta_at(t_index);
 
   launch_add_noise_direct_fp16(original_samples, noise, alpha, beta, N, stream);
 }
@@ -61,7 +61,7 @@ void LibreDiffusionPipeline::encode_image(
     if(config_.do_add_noise)
       add_noise_direct(latent_out, init_noise_->data(), /*t_index=*/0, latent_elements, stream);
     else
-      launch_scalar_mul_inplace_fp16(latent_out, alpha_prod_t_sqrt_host_[0], latent_elements, stream);
+      launch_scalar_mul_inplace_fp16(latent_out, alpha_at(0), latent_elements, stream);
   }
 }
 
@@ -88,7 +88,7 @@ void LibreDiffusionPipeline::encode_image(
     if(config_.do_add_noise)
       add_noise_direct(latent_out, init_noise_->data(), /*t_index=*/0, latent_elements, stream);
     else
-      launch_scalar_mul_inplace_fp16(latent_out, alpha_prod_t_sqrt_host_[0], latent_elements, stream);
+      launch_scalar_mul_inplace_fp16(latent_out, alpha_at(0), latent_elements, stream);
   }
 }
 

--- a/src/librediffusion.vae.cpp
+++ b/src/librediffusion.vae.cpp
@@ -45,24 +45,11 @@ void LibreDiffusionPipeline::encode_image(
     launch_scalar_mul_inplace_fp16(latent_out, vae_scaling_factor, latent_elements, stream);
   }
 
-  // Initialize the img2img latent at timestep 0. do_add_noise gates ALL stochastic noise in the
-  // pipeline — this encode-time noise@t0 AND the multi-step inter-step noise (see predict_x0_batch) —
-  // so the "Add noise" setting is consumed identically at 1 step and N steps (previously it only
-  // affected the multi-step inter-step buffer, silently no-op at 1 step).
-  //   do_add_noise=true  (default): x_t = alpha0*latent + beta0*noise  — matches every StreamDiffusion
-  //                                 reference (upstream cumulo-autumn, the bundled fork, daydream), so
-  //                                 the validated goldens (run at the default) are unchanged.
-  //   do_add_noise=false:          x_t = alpha0*latent  (scaled clean latent, beta0*noise dropped) —
-  //                                 the reference's no-noise branch; makes the toggle meaningful even
-  //                                 for a 1-step pipeline, where there is no inter-step noise to gate.
-  // Guard on scheduler init (prepare() must have run to populate alpha/beta).
+  // x_t = alpha0*latent + beta0*init_noise[0], unconditionally: pipeline.py encode_image() does not
+  // consult do_add_noise, which gates only the inter-step seams (see predict_x0_batch). Guarded on
+  // prepare() having populated alpha/beta.
   if(init_noise_ && !alpha_prod_t_sqrt_host_.empty())
-  {
-    if(config_.do_add_noise)
-      add_noise_direct(latent_out, init_noise_->data(), /*t_index=*/0, latent_elements, stream);
-    else
-      launch_scalar_mul_inplace_fp16(latent_out, alpha_at(0), latent_elements, stream);
-  }
+    add_noise_direct(latent_out, init_noise_->data(), /*t_index=*/0, latent_elements, stream);
 }
 
 void LibreDiffusionPipeline::encode_image(
@@ -80,16 +67,9 @@ void LibreDiffusionPipeline::encode_image(
 
   const int latent_elements
       = config_.batch_size * 4 * config_.latent_height * config_.latent_width;
-  // do_add_noise gates all pipeline noise (encode-time @t0 + inter-step); consumed identically at 1 and
-  // N steps. true (default): alpha0*latent + beta0*noise (reference-faithful). false: alpha0*latent
-  // (scaled clean latent). See the __half overload above for the full rationale.
+  // Unconditional, as in the __half overload above.
   if(init_noise_ && !alpha_prod_t_sqrt_host_.empty())
-  {
-    if(config_.do_add_noise)
-      add_noise_direct(latent_out, init_noise_->data(), /*t_index=*/0, latent_elements, stream);
-    else
-      launch_scalar_mul_inplace_fp16(latent_out, alpha_at(0), latent_elements, stream);
-  }
+    add_noise_direct(latent_out, init_noise_->data(), /*t_index=*/0, latent_elements, stream);
 }
 
 void LibreDiffusionPipeline::decode_latent(

--- a/src/librediffusion.workflows.cpp
+++ b/src/librediffusion.workflows.cpp
@@ -257,8 +257,8 @@ void LibreDiffusionPipeline::img2img(
     const uint8_t* cpu_rgba_input, uint8_t* cpu_rgba_output, int iw, int ih)
 {
   int batch_size = config_.batch_size;
-  // The HOST buffers hold ONE frame: the caller passes iw*ih*4 bytes, and img_preprocess /
-  // img_postprocess convert exactly one image ("FIXME batch not handled" in images.cpp). Sizing the
+  // The HOST buffers hold ONE frame: the caller passes iw*ih*4 bytes, and only one frame crosses the
+  // boundary in either direction (img_preprocess replicates it to the batch extent). Sizing the
   // host<->device copies by batch_size read `batch_size-1` extra frames past the end of the caller's
   // input and wrote that much past the end of its output — a plain heap overflow of a buffer this
   // library does not own, which is why batch 2 surfaced as glibc corruption or a SIGSEGV in cudaFree
@@ -322,8 +322,8 @@ void LibreDiffusionPipeline::img2img(
 void LibreDiffusionPipeline::txt2img(uint8_t* cpu_rgba_output, int iw, int ih)
 {
   int batch_size = config_.batch_size;
-  // The HOST buffers hold ONE frame: the caller passes iw*ih*4 bytes, and img_preprocess /
-  // img_postprocess convert exactly one image ("FIXME batch not handled" in images.cpp). Sizing the
+  // The HOST buffers hold ONE frame: the caller passes iw*ih*4 bytes, and only one frame crosses the
+  // boundary in either direction (img_preprocess replicates it to the batch extent). Sizing the
   // host<->device copies by batch_size read `batch_size-1` extra frames past the end of the caller's
   // input and wrote that much past the end of its output — a plain heap overflow of a buffer this
   // library does not own, which is why batch 2 surfaced as glibc corruption or a SIGSEGV in cudaFree

--- a/src/librediffusion.workflows.cpp
+++ b/src/librediffusion.workflows.cpp
@@ -304,8 +304,11 @@ void LibreDiffusionPipeline::img2img(
       cpu_rgba_output, device_rgba_output_correct_size, rgba_input_size,
       cudaMemcpyDeviceToHost, stream_);
 
-  // Wait for all operations to complete
-  //cudaStreamSynchronize(stream_);
+  // Wait for all operations to complete. This must NOT be optional: the copy above targets the
+  // CALLER's host buffer, so returning while it is still in flight lets that buffer (or the whole
+  // pipeline, if the host destroys it) go away underneath an active DMA. txt2img() below has always
+  // synchronized; this one was commented out.
+  cudaStreamSynchronize(stream_);
 }
 
 void LibreDiffusionPipeline::txt2img(uint8_t* cpu_rgba_output, int iw, int ih)

--- a/src/librediffusion.workflows.cpp
+++ b/src/librediffusion.workflows.cpp
@@ -257,13 +257,9 @@ void LibreDiffusionPipeline::img2img(
     const uint8_t* cpu_rgba_input, uint8_t* cpu_rgba_output, int iw, int ih)
 {
   int batch_size = config_.batch_size;
-  // The HOST buffers hold ONE frame: the caller passes iw*ih*4 bytes, and only one frame crosses the
-  // boundary in either direction (img_preprocess replicates it to the batch extent). Sizing the
-  // host<->device copies by batch_size read `batch_size-1` extra frames past the end of the caller's
-  // input and wrote that much past the end of its output — a plain heap overflow of a buffer this
-  // library does not own, which is why batch 2 surfaced as glibc corruption or a SIGSEGV in cudaFree
-  // at teardown, long after the frame had been returned. The DEVICE staging buffers keep the batch
-  // extent because the VAE really does run batch_size rows.
+  // The HOST buffers hold ONE frame: the caller passes iw*ih*4 bytes and only one frame crosses the
+  // boundary in either direction (img_preprocess replicates it to the batch extent). The DEVICE
+  // staging buffers keep the batch extent because the VAE really does run batch_size rows.
   size_t rgba_frame_size = (size_t)ih * iw * 4;
   size_t rgba_input_size = (size_t)batch_size * ih * iw * 4;
   size_t rgba_vae_size = (size_t)batch_size * this->config_.height * this->config_.width * 4;
@@ -312,23 +308,17 @@ void LibreDiffusionPipeline::img2img(
       cpu_rgba_output, device_rgba_output_correct_size, rgba_frame_size,
       cudaMemcpyDeviceToHost, stream_);
 
-  // Wait for all operations to complete. This must NOT be optional: the copy above targets the
-  // CALLER's host buffer, so returning while it is still in flight lets that buffer (or the whole
-  // pipeline, if the host destroys it) go away underneath an active DMA. txt2img() below has always
-  // synchronized; this one was commented out.
+  // The copy above targets the CALLER's host buffer: returning while it is in flight lets that
+  // buffer (or the whole pipeline) go away underneath an active DMA.
   cudaStreamSynchronize(stream_);
 }
 
 void LibreDiffusionPipeline::txt2img(uint8_t* cpu_rgba_output, int iw, int ih)
 {
   int batch_size = config_.batch_size;
-  // The HOST buffers hold ONE frame: the caller passes iw*ih*4 bytes, and only one frame crosses the
-  // boundary in either direction (img_preprocess replicates it to the batch extent). Sizing the
-  // host<->device copies by batch_size read `batch_size-1` extra frames past the end of the caller's
-  // input and wrote that much past the end of its output — a plain heap overflow of a buffer this
-  // library does not own, which is why batch 2 surfaced as glibc corruption or a SIGSEGV in cudaFree
-  // at teardown, long after the frame had been returned. The DEVICE staging buffers keep the batch
-  // extent because the VAE really does run batch_size rows.
+  // The HOST buffers hold ONE frame: the caller passes iw*ih*4 bytes and only one frame crosses the
+  // boundary in either direction (img_preprocess replicates it to the batch extent). The DEVICE
+  // staging buffers keep the batch extent because the VAE really does run batch_size rows.
   size_t rgba_frame_size = (size_t)ih * iw * 4;
   size_t rgba_input_size = (size_t)batch_size * ih * iw * 4;
   size_t rgba_vae_size = (size_t)batch_size * this->config_.height * this->config_.width * 4;

--- a/src/librediffusion.workflows.cpp
+++ b/src/librediffusion.workflows.cpp
@@ -235,7 +235,7 @@ void LibreDiffusionPipeline::txt2img_sd_turbo_impl(
 
   // SD-Turbo formula: x_0_pred_out = (x_t_latent - beta * model_pred) / alpha
   // Step 1: model_pred *= beta
-  float beta = beta_prod_t_sqrt_host_[0];
+  float beta = beta_at(0);
   launch_scalar_mul_inplace_fp16(model_pred.data(), beta, latent_size, stream);
 
   // Step 2: x_0_pred_out = x_t_latent - model_pred
@@ -244,7 +244,7 @@ void LibreDiffusionPipeline::txt2img_sd_turbo_impl(
       latent_size, stream);
 
   // Step 3: x_0_pred_out /= alpha
-  float alpha = alpha_prod_t_sqrt_host_[0];
+  float alpha = alpha_at(0);
   CUDATensor<__half> x_0_pred_final(latent_size);
   launch_scalar_div_fp16(
       unet_output_x_0_pred_->data(), x_0_pred_final.data(), alpha, latent_size, stream);

--- a/src/librediffusion.workflows.cpp
+++ b/src/librediffusion.workflows.cpp
@@ -257,9 +257,17 @@ void LibreDiffusionPipeline::img2img(
     const uint8_t* cpu_rgba_input, uint8_t* cpu_rgba_output, int iw, int ih)
 {
   int batch_size = config_.batch_size;
-  size_t rgba_input_size = batch_size * ih * iw * 4;
-  size_t rgba_vae_size = batch_size * this->config_.height * this->config_.width * 4;
-  size_t tensor_size = batch_size * 3 * this->config_.height * this->config_.width;
+  // The HOST buffers hold ONE frame: the caller passes iw*ih*4 bytes, and img_preprocess /
+  // img_postprocess convert exactly one image ("FIXME batch not handled" in images.cpp). Sizing the
+  // host<->device copies by batch_size read `batch_size-1` extra frames past the end of the caller's
+  // input and wrote that much past the end of its output — a plain heap overflow of a buffer this
+  // library does not own, which is why batch 2 surfaced as glibc corruption or a SIGSEGV in cudaFree
+  // at teardown, long after the frame had been returned. The DEVICE staging buffers keep the batch
+  // extent because the VAE really does run batch_size rows.
+  size_t rgba_frame_size = (size_t)ih * iw * 4;
+  size_t rgba_input_size = (size_t)batch_size * ih * iw * 4;
+  size_t rgba_vae_size = (size_t)batch_size * this->config_.height * this->config_.width * 4;
+  size_t tensor_size = (size_t)batch_size * 3 * this->config_.height * this->config_.width;
 
   // Allocate or resize device buffers if needed
   if(!device_rgba_input_ || device_rgba_input_->size() < rgba_input_size)
@@ -288,7 +296,7 @@ void LibreDiffusionPipeline::img2img(
 
   // Copy input from CPU to GPU
   cudaMemcpyAsync(
-      device_rgba_input_->data(), cpu_rgba_input, rgba_input_size,
+      device_rgba_input_->data(), cpu_rgba_input, rgba_frame_size,
       cudaMemcpyHostToDevice, stream_);
 
   img_preprocess(device_rgba_input_->data(), iw, ih);
@@ -301,7 +309,7 @@ void LibreDiffusionPipeline::img2img(
 
   // Copy output from GPU to CPU
   cudaMemcpyAsync(
-      cpu_rgba_output, device_rgba_output_correct_size, rgba_input_size,
+      cpu_rgba_output, device_rgba_output_correct_size, rgba_frame_size,
       cudaMemcpyDeviceToHost, stream_);
 
   // Wait for all operations to complete. This must NOT be optional: the copy above targets the
@@ -314,9 +322,17 @@ void LibreDiffusionPipeline::img2img(
 void LibreDiffusionPipeline::txt2img(uint8_t* cpu_rgba_output, int iw, int ih)
 {
   int batch_size = config_.batch_size;
-  size_t rgba_input_size = batch_size * ih * iw * 4;
-  size_t rgba_vae_size = batch_size * this->config_.height * this->config_.width * 4;
-  size_t tensor_size = batch_size * 3 * this->config_.height * this->config_.width;
+  // The HOST buffers hold ONE frame: the caller passes iw*ih*4 bytes, and img_preprocess /
+  // img_postprocess convert exactly one image ("FIXME batch not handled" in images.cpp). Sizing the
+  // host<->device copies by batch_size read `batch_size-1` extra frames past the end of the caller's
+  // input and wrote that much past the end of its output — a plain heap overflow of a buffer this
+  // library does not own, which is why batch 2 surfaced as glibc corruption or a SIGSEGV in cudaFree
+  // at teardown, long after the frame had been returned. The DEVICE staging buffers keep the batch
+  // extent because the VAE really does run batch_size rows.
+  size_t rgba_frame_size = (size_t)ih * iw * 4;
+  size_t rgba_input_size = (size_t)batch_size * ih * iw * 4;
+  size_t rgba_vae_size = (size_t)batch_size * this->config_.height * this->config_.width * 4;
+  size_t tensor_size = (size_t)batch_size * 3 * this->config_.height * this->config_.width;
 
   // Allocate or resize device buffers if needed
   if(!device_rgba_output_ || device_rgba_output_->size() < rgba_input_size)
@@ -340,7 +356,7 @@ void LibreDiffusionPipeline::txt2img(uint8_t* cpu_rgba_output, int iw, int ih)
 
   // Copy output from GPU to CPU
   cudaMemcpyAsync(
-      cpu_rgba_output, device_rgba_output_correct_size, rgba_input_size,
+      cpu_rgba_output, device_rgba_output_correct_size, rgba_frame_size,
       cudaMemcpyDeviceToHost, stream_);
 
   // Wait for all operations to complete

--- a/src/librediffusion_c.cpp
+++ b/src/librediffusion_c.cpp
@@ -17,9 +17,12 @@
 #include <cstdio>
 #include <cstring>
 #include <memory>
+#include <mutex>
 #include <new>
 #include <span>
 #include <string>
+#include <type_traits>
+#include <unordered_set>
 #include <vector>
 
 #define LIBREDIFFUSION_VERSION_MAJOR 1
@@ -27,50 +30,77 @@
 #define LIBREDIFFUSION_VERSION_PATCH 0
 #define LIBREDIFFUSION_VERSION_STRING "1.0.0"
 
-/* Handle validation (L-11).
+/* Handle validation (L-11, S-03).
  *
- * A C handle is the one thing a host cannot check for itself, so the library has to. Each handle
- * carries a magic word that is set on construction and CLEARED just before the block is freed, and
- * every entry point checks it. That turns the three mistakes hosts actually make — passing a
- * destroyed handle, destroying twice, and using the out-parameter a failed create never wrote —
- * into ordinary error codes instead of a glibc double-free abort, a SIGSEGV, or (worst of all) a
- * destroyed handle that keeps answering queries with garbage.
+ * A C handle is the one thing a host cannot check for itself, so the library has to: passing a
+ * destroyed handle, destroying twice, and using the out-parameter a failed create never wrote all
+ * have to become ordinary error codes rather than a glibc double-free abort or a SIGSEGV.
  *
- * Reading the magic out of a freed block is not something the standard blesses, but it is the only
- * mitigation available at a C boundary and it converts the overwhelmingly common cases (the block
- * is still mapped and either untouched or reused) into a clean rejection. */
-#define LIBREDIFFUSION_CONFIG_MAGIC 0x4C524443u   /* 'LRDC' */
-#define LIBREDIFFUSION_PIPELINE_MAGIC 0x4C524450u /* 'LRDP' */
+ * The check therefore lives OUTSIDE the block it validates. A registry of live handles is consulted
+ * by pointer value and never dereferences an untrusted handle. */
 
 struct librediffusion_config_t
 {
-  unsigned int magic{LIBREDIFFUSION_CONFIG_MAGIC};
   librediffusion::LibreDiffusionConfig cpp_config;
 };
 
 struct librediffusion_pipeline_t
 {
-  unsigned int magic{LIBREDIFFUSION_PIPELINE_MAGIC};
   std::unique_ptr<librediffusion::LibreDiffusionPipeline> cpp_pipeline;
 };
 
 namespace
 {
+template <typename T>
+struct handle_registry
+{
+  std::mutex mutex;
+  std::unordered_set<const void*> live;
+};
+
+// Deliberately leaked: a host may destroy a handle from a static destructor of its own, which can
+// run after any function-local static would have been torn down.
+template <typename T>
+handle_registry<T>& registry()
+{
+  static auto* r = new handle_registry<T>{};
+  return *r;
+}
+
+template <typename H>
+void register_handle(H h)
+{
+  auto& r = registry<std::remove_pointer_t<H>>();
+  std::lock_guard lock{r.mutex};
+  r.live.insert(h);
+}
+
+// True only for the caller that actually removed it, so two concurrent destroys cannot both free.
+template <typename H>
+bool unregister_handle(H h)
+{
+  auto& r = registry<std::remove_pointer_t<H>>();
+  std::lock_guard lock{r.mutex};
+  return r.live.erase(h) != 0;
+}
+
+template <typename H>
+bool is_live(H h)
+{
+  auto& r = registry<std::remove_pointer_t<H>>();
+  std::lock_guard lock{r.mutex};
+  return r.live.count(h) != 0;
+}
+
 // A live, never-destroyed config handle.
 inline bool valid(librediffusion_config_handle c)
 {
-  return c && c->magic == LIBREDIFFUSION_CONFIG_MAGIC;
+  return c && is_live(c);
 }
 // A live pipeline handle that also owns a pipeline (i.e. usable for real work).
 inline bool valid(librediffusion_pipeline_handle p)
 {
-  return p && p->magic == LIBREDIFFUSION_PIPELINE_MAGIC && p->cpp_pipeline;
-}
-// A live pipeline handle, whether or not construction got as far as the pipeline itself. Only
-// destroy needs this weaker form.
-inline bool valid_handle(librediffusion_pipeline_handle p)
-{
-  return p && p->magic == LIBREDIFFUSION_PIPELINE_MAGIC;
+  return p && is_live(p) && p->cpp_pipeline;
 }
 } // anonymous namespace
 
@@ -248,18 +278,20 @@ librediffusion_config_create(librediffusion_config_handle* config)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   *config = nullptr;
 
-  return try_catch_host([&]() { *config = new librediffusion_config_t{}; });
+  return try_catch_host([&]() {
+    auto c = std::make_unique<librediffusion_config_t>();
+    register_handle(c.get());
+    *config = c.release();
+  });
 }
 
 LIBREDIFFUSION_API void LIBREDIFFUSION_CALL
 librediffusion_config_destroy(librediffusion_config_handle config)
 {
-  // NULL is documented as safe; so, now, is a handle that was already destroyed (previously a
-  // glibc "double free detected" -> SIGABRT). Clear the magic BEFORE freeing so the block cannot
-  // pass validation again even if the allocator hands it straight back out.
-  if (!valid(config))
+  // NULL is documented as safe; so is a handle that was already destroyed (previously a glibc
+  // "double free detected" -> SIGABRT).
+  if (!config || !unregister_handle(config))
     return;
-  config->magic = 0;
   delete config;
 }
 
@@ -272,7 +304,9 @@ librediffusion_config_clone(
   *dst = nullptr;
 
   return try_catch_host([&]() {
-    *dst = new librediffusion_config_t{LIBREDIFFUSION_CONFIG_MAGIC, src->cpp_config};
+    auto c = std::make_unique<librediffusion_config_t>(src->cpp_config);
+    register_handle(c.get());
+    *dst = c.release();
   });
 }
 
@@ -661,6 +695,7 @@ librediffusion_pipeline_create(
     auto p = std::make_unique<librediffusion_pipeline_t>();
     p->cpp_pipeline = std::make_unique<librediffusion::LibreDiffusionPipeline>(
         config->cpp_config);
+    register_handle(p.get());
     *pipeline = p.release();
   });
 }
@@ -669,12 +704,10 @@ LIBREDIFFUSION_API void LIBREDIFFUSION_CALL
 librediffusion_pipeline_destroy(librediffusion_pipeline_handle pipeline)
 {
   // NULL and already-destroyed are both no-ops (a second destroy used to re-run the whole dtor
-  // chain — CUDA stream, graph, TensorRT contexts — on freed memory, i.e. SIGSEGV). valid_handle()
-  // rather than valid(): a pipeline whose construction failed has no cpp_pipeline but still owns
-  // the wrapper, and must still be freed.
-  if (!valid_handle(pipeline))
+  // chain — CUDA stream, graph, TensorRT contexts — on freed memory, i.e. SIGSEGV). Registration is
+  // not conditional on cpp_pipeline: a pipeline whose construction failed still owns the wrapper.
+  if (!pipeline || !unregister_handle(pipeline))
     return;
-  pipeline->magic = 0;
   delete pipeline;
 }
 

--- a/src/librediffusion_c.cpp
+++ b/src/librediffusion_c.cpp
@@ -85,6 +85,20 @@ librediffusion_error_t try_catch_wrapper(Func&& func)
     return LIBREDIFFUSION_ERROR_INTERNAL;
   }
 }
+
+// Guard every inference entry point against a pipeline whose conditioning / scheduler the host has
+// not supplied yet. Construction succeeds long before prepare_embeds()/prepare_scheduler() are
+// called, and the denoise path dereferences both unconditionally, so an early frame used to be a
+// guaranteed null-deref rather than an error code. Returns SUCCESS when the pipeline is ready.
+librediffusion_error_t check_inference_ready(librediffusion_pipeline_handle pipeline)
+{
+  if (const char* why = pipeline->cpp_pipeline->inference_readiness())
+  {
+    std::fprintf(stderr, "[librediffusion] NOT_INITIALIZED: %s\n", why);
+    return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
+  }
+  return LIBREDIFFUSION_SUCCESS;
+}
 } // anonymous namespace
 
 /*===========================================================================*/
@@ -955,6 +969,9 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL librediffusion_img
   if (width <= 0 || height <= 0)
     return LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS;
 
+  if (librediffusion_error_t e = check_inference_ready(pipeline); e != LIBREDIFFUSION_SUCCESS)
+    return e;
+
   return try_catch_wrapper([&]() {
     pipeline->cpp_pipeline->img2img(cpu_rgba_input, cpu_rgba_output, width, height);
   });
@@ -970,6 +987,9 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL librediffusion_txt
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   if (width <= 0 || height <= 0)
     return LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS;
+
+  if (librediffusion_error_t e = check_inference_ready(pipeline); e != LIBREDIFFUSION_SUCCESS)
+    return e;
 
   return try_catch_wrapper([&]() {
     pipeline->cpp_pipeline->txt2img(cpu_rgba_output, width, height);
@@ -990,6 +1010,9 @@ librediffusion_img2img_gpu_half(
   if (!image_in || !image_out)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
 
+  if (librediffusion_error_t e = check_inference_ready(pipeline); e != LIBREDIFFUSION_SUCCESS)
+    return e;
+
   return try_catch_wrapper([&]() {
     pipeline->cpp_pipeline->img2img_impl(
         to_half_ptr(image_in),
@@ -1008,6 +1031,9 @@ librediffusion_img2img_gpu_float(
   if (!image_in || !image_out)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
 
+  if (librediffusion_error_t e = check_inference_ready(pipeline); e != LIBREDIFFUSION_SUCCESS)
+    return e;
+
   return try_catch_wrapper([&]() {
     pipeline->cpp_pipeline->img2img_impl(
         image_in,
@@ -1025,6 +1051,9 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL librediffusion_txt
   if (!image_out)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
 
+  if (librediffusion_error_t e = check_inference_ready(pipeline); e != LIBREDIFFUSION_SUCCESS)
+    return e;
+
   return try_catch_wrapper([&]() {
     pipeline->cpp_pipeline->txt2img_impl(
         to_half_ptr(image_out),
@@ -1041,6 +1070,9 @@ librediffusion_txt2img_sd_turbo_gpu(
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!image_out)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
+
+  if (librediffusion_error_t e = check_inference_ready(pipeline); e != LIBREDIFFUSION_SUCCESS)
+    return e;
 
   return try_catch_wrapper([&]() {
     pipeline->cpp_pipeline->txt2img_sd_turbo_impl(
@@ -1119,6 +1151,9 @@ librediffusion_predict_x0_batch(
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!x_t_latent_in || !x_0_pred_out)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
+
+  if (librediffusion_error_t e = check_inference_ready(pipeline); e != LIBREDIFFUSION_SUCCESS)
+    return e;
 
   return try_catch_wrapper([&]() {
     pipeline->cpp_pipeline->predict_x0_batch(

--- a/src/librediffusion_c.cpp
+++ b/src/librediffusion_c.cpp
@@ -822,9 +822,18 @@ librediffusion_pipeline_reinit_buffers(
   if (!valid(config))
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
 
-  return try_catch_wrapper([&]() {
+  bool rejected = false;
+  librediffusion_error_t err = try_catch_wrapper([&]() {
+    std::string why = pipeline->cpp_pipeline->geometry_rejection(config->cpp_config);
+    if(!why.empty())
+    {
+      std::fprintf(stderr, "[librediffusion] INVALID_DIMENSIONS: %s\n", why.c_str());
+      rejected = true;
+      return;
+    }
     pipeline->cpp_pipeline->reinit_buffers(config->cpp_config);
   });
+  return rejected ? LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS : err;
 }
 
 /*===========================================================================*/

--- a/src/librediffusion_c.cpp
+++ b/src/librediffusion_c.cpp
@@ -136,6 +136,27 @@ librediffusion_error_t check_inference_ready(librediffusion_pipeline_handle pipe
   }
   return LIBREDIFFUSION_SUCCESS;
 }
+// Reject a prepare_* / token call whose DECLARED shape disagrees with the pipeline's configured text
+// geometry (L-06). These entry points size the device buffer from the CALL's arguments, but every
+// consumer reads config_.text_seq_len * config_.text_hidden_dim back out of it with a raw
+// cudaMemcpyAsync — so a smaller declared shape is an out-of-bounds DEVICE read that surfaces later,
+// somewhere else, as an opaque cudaErrorInvalidDevice, after the output buffer has already been
+// partially written.
+librediffusion_error_t check_text_dims(
+    librediffusion_pipeline_handle pipeline, int seq_len, int hidden_dim, const char* what)
+{
+  const auto& cfg = pipeline->cpp_pipeline->config();
+  if (seq_len != cfg.text_seq_len || hidden_dim != cfg.text_hidden_dim)
+  {
+    std::fprintf(
+        stderr,
+        "[librediffusion] INVALID_DIMENSIONS: %s got [seq=%d, hidden=%d] but the pipeline is "
+        "configured for [seq=%d, hidden=%d]\n",
+        what, seq_len, hidden_dim, cfg.text_seq_len, cfg.text_hidden_dim);
+    return LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS;
+  }
+  return LIBREDIFFUSION_SUCCESS;
+}
 } // anonymous namespace
 
 /*===========================================================================*/
@@ -713,6 +734,9 @@ librediffusion_prepare_embeds(
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   if (seq_len <= 0 || hidden_dim <= 0)
     return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
+  if (librediffusion_error_t e = check_text_dims(pipeline, seq_len, hidden_dim, "prepare_embeds");
+      e != LIBREDIFFUSION_SUCCESS)
+    return e;
 
   return try_catch_wrapper([&]() {
     pipeline->cpp_pipeline->prepare_embeds(
@@ -731,6 +755,9 @@ librediffusion_prepare_null_embeds(
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   if (seq_len <= 0 || hidden_dim <= 0)
     return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
+  if (librediffusion_error_t e = check_text_dims(pipeline, seq_len, hidden_dim, "prepare_null_embeds");
+      e != LIBREDIFFUSION_SUCCESS)
+    return e;
 
   return try_catch_wrapper([&]() {
     pipeline->cpp_pipeline->prepare_null_embeds(
@@ -749,6 +776,9 @@ librediffusion_prepare_negative_embeds(
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   if (seq_len <= 0 || hidden_dim <= 0)
     return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
+  if (librediffusion_error_t e = check_text_dims(pipeline, seq_len, hidden_dim, "prepare_negative_embeds");
+      e != LIBREDIFFUSION_SUCCESS)
+    return e;
 
   return try_catch_wrapper([&]() {
     pipeline->cpp_pipeline->prepare_negative_embeds(
@@ -768,6 +798,9 @@ librediffusion_blend_embeds(
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   if (num_embeddings <= 0 || seq_len <= 0 || hidden_dim <= 0)
     return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
+  if (librediffusion_error_t e = check_text_dims(pipeline, seq_len, hidden_dim, "blend_embeds");
+      e != LIBREDIFFUSION_SUCCESS)
+    return e;
 
   return try_catch_wrapper([&]() {
     // Convert librediffusion_half_t* const* to __half* const*
@@ -790,6 +823,21 @@ librediffusion_prepare_sdxl_conditioning(
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!text_embeds || !time_ids)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
+  // No shapes are passed here: both buffers are read using the pipeline's OWN configured dimensions.
+  // The least we can do is refuse the call on a pipeline that has no SDXL conditioning to fill, where
+  // the dimensions are meaningless and the copy would be sized from stale defaults.
+  {
+    const auto& cfg = pipeline->cpp_pipeline->config();
+    if (cfg.pooled_embedding_dim <= 0 || cfg.time_ids_dim <= 0)
+    {
+      std::fprintf(
+          stderr,
+          "[librediffusion] INVALID_DIMENSIONS: prepare_sdxl_conditioning on a pipeline with "
+          "pooled_embedding_dim=%d, time_ids_dim=%d (call config_set_sdxl_config first)\n",
+          cfg.pooled_embedding_dim, cfg.time_ids_dim);
+      return LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS;
+    }
+  }
 
   return try_catch_wrapper([&]() {
     pipeline->cpp_pipeline->prepare_sdxl_conditioning(
@@ -926,6 +974,20 @@ librediffusion_set_ipadapter_tokens(
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!pos_tokens)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
+  if (num_tokens <= 0 || dim <= 0)
+    return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
+  // Same class as L-06: the token buffer is sized num_tokens*dim from these arguments, but the
+  // extended-ehs assembly reads ipadapter_num_tokens_ * config_.text_hidden_dim back out of it. A
+  // `dim` that is not the pipeline's cross-attention width is an out-of-bounds device read.
+  if (dim != pipeline->cpp_pipeline->config().text_hidden_dim)
+  {
+    std::fprintf(
+        stderr,
+        "[librediffusion] INVALID_DIMENSIONS: set_ipadapter_tokens got dim=%d but the pipeline's "
+        "cross-attention width is %d\n",
+        dim, pipeline->cpp_pipeline->config().text_hidden_dim);
+    return LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS;
+  }
   return try_catch_wrapper([&]() {
     pipeline->cpp_pipeline->set_ipadapter_tokens(
         to_half_ptr(pos_tokens), to_half_ptr(neg_tokens), num_tokens, dim);

--- a/src/librediffusion_c.cpp
+++ b/src/librediffusion_c.cpp
@@ -9,6 +9,8 @@
 #include "librediffusion.hpp"
 #include "tensorrt_wrappers.hpp"
 
+#include "cuda_error_state.hpp"
+
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
 
@@ -78,27 +80,38 @@ inline bool valid_handle(librediffusion_pipeline_handle p)
 
 namespace
 {
-thread_local cudaError_t g_last_cuda_error = cudaSuccess;
+using librediffusion::cuda_context_lost;
+using librediffusion::cuda_error_is_context_fatal;
+using librediffusion::drain_cuda_error;
+using librediffusion::g_last_cuda_error;
+using librediffusion::set_cuda_error;
 
-void set_cuda_error(cudaError_t err)
+// For the entry points that hold a cudaError_t of their own: record it, consume whatever the runtime
+// still has pending, and answer with the right one of the two codes.
+librediffusion_error_t report_cuda_failure(cudaError_t err)
 {
-  g_last_cuda_error = err;
+  drain_cuda_error();
+  set_cuda_error(err);
+  if (cuda_error_is_context_fatal(err))
+    librediffusion::g_cuda_context_lost.store(true, std::memory_order_relaxed);
+  return cuda_error_is_context_fatal(err) ? LIBREDIFFUSION_ERROR_CUDA_CONTEXT_LOST
+                                          : LIBREDIFFUSION_ERROR_CUDA_ERROR;
 }
 
 librediffusion_error_t check_cuda_error()
 {
-  cudaError_t err = cudaGetLastError();
-  if (err != cudaSuccess)
-  {
-    set_cuda_error(err);
-    return LIBREDIFFUSION_ERROR_CUDA_ERROR;
-  }
-  return LIBREDIFFUSION_SUCCESS;
+  cudaError_t err = drain_cuda_error();
+  if (err == cudaSuccess)
+    return LIBREDIFFUSION_SUCCESS;
+  return cuda_error_is_context_fatal(err) ? LIBREDIFFUSION_ERROR_CUDA_CONTEXT_LOST
+                                          : LIBREDIFFUSION_ERROR_CUDA_ERROR;
 }
 
 template <typename Func>
 librediffusion_error_t try_catch_wrapper(Func&& func)
 {
+  if (cuda_context_lost())
+    return LIBREDIFFUSION_ERROR_CUDA_CONTEXT_LOST;
   try
   {
     func();
@@ -106,6 +119,7 @@ librediffusion_error_t try_catch_wrapper(Func&& func)
   }
   catch (const std::bad_alloc&)
   {
+    drain_cuda_error();
     std::fprintf(stderr, "[librediffusion] OUT_OF_MEMORY\n");
     return LIBREDIFFUSION_ERROR_OUT_OF_MEMORY;
   }
@@ -113,11 +127,13 @@ librediffusion_error_t try_catch_wrapper(Func&& func)
   {
     // Surface the message so the C-API caller (harness/app) can see WHY an internal error
     // occurred instead of an opaque -99. Without this every throw collapsed to the same code.
+    drain_cuda_error();
     std::fprintf(stderr, "[librediffusion] INTERNAL ERROR: %s\n", e.what());
     return LIBREDIFFUSION_ERROR_INTERNAL;
   }
   catch (...)
   {
+    drain_cuda_error();
     std::fprintf(stderr, "[librediffusion] INTERNAL ERROR: unknown (non-std::exception)\n");
     return LIBREDIFFUSION_ERROR_INTERNAL;
   }
@@ -1594,6 +1610,8 @@ librediffusion_error_string(librediffusion_error_t error)
       return "Invalid dimensions";
     case LIBREDIFFUSION_ERROR_FILE_NOT_FOUND:
       return "File not found";
+    case LIBREDIFFUSION_ERROR_CUDA_CONTEXT_LOST:
+      return "CUDA context lost (unrecoverable; restart the process)";
     case LIBREDIFFUSION_ERROR_INTERNAL:
     default:
       return "Internal error";
@@ -1639,10 +1657,7 @@ librediffusion_pipeline_synchronize(librediffusion_pipeline_handle pipeline)
 
   cudaError_t err = cudaStreamSynchronize(pipeline->cpp_pipeline->stream_);
   if (err != cudaSuccess)
-  {
-    set_cuda_error(err);
-    return LIBREDIFFUSION_ERROR_CUDA_ERROR;
-  }
+    return report_cuda_failure(err);
   return LIBREDIFFUSION_SUCCESS;
 }
 
@@ -1667,7 +1682,7 @@ LIBREDIFFUSION_API void* LIBREDIFFUSION_CALL librediffusion_cuda_malloc(size_t s
   cudaError_t err = cudaMalloc(&ptr, size);
   if (err != cudaSuccess)
   {
-    set_cuda_error(err);
+    report_cuda_failure(err);
     return nullptr;
   }
   return ptr;
@@ -1679,9 +1694,7 @@ LIBREDIFFUSION_API void LIBREDIFFUSION_CALL librediffusion_cuda_free(void* ptr)
   {
     cudaError_t err = cudaFree(ptr);
     if (err != cudaSuccess)
-    {
-      set_cuda_error(err);
-    }
+      report_cuda_failure(err);
   }
 }
 
@@ -1691,7 +1704,7 @@ LIBREDIFFUSION_API void* LIBREDIFFUSION_CALL librediffusion_cuda_malloc_host(siz
   cudaError_t err = cudaMallocHost(&ptr, size);
   if (err != cudaSuccess)
   {
-    set_cuda_error(err);
+    report_cuda_failure(err);
     return nullptr;
   }
   return ptr;
@@ -1703,9 +1716,7 @@ LIBREDIFFUSION_API void LIBREDIFFUSION_CALL librediffusion_cuda_free_host(void* 
   {
     cudaError_t err = cudaFreeHost(ptr);
     if (err != cudaSuccess)
-    {
-      set_cuda_error(err);
-    }
+      report_cuda_failure(err);
   }
 }
 
@@ -1714,10 +1725,7 @@ librediffusion_cuda_memcpy_h2d(void* dst, const void* src, size_t size)
 {
   cudaError_t err = cudaMemcpy(dst, src, size, cudaMemcpyHostToDevice);
   if (err != cudaSuccess)
-  {
-    set_cuda_error(err);
-    return LIBREDIFFUSION_ERROR_CUDA_ERROR;
-  }
+    return report_cuda_failure(err);
   return LIBREDIFFUSION_SUCCESS;
 }
 
@@ -1726,10 +1734,7 @@ librediffusion_cuda_memcpy_d2h(void* dst, const void* src, size_t size)
 {
   cudaError_t err = cudaMemcpy(dst, src, size, cudaMemcpyDeviceToHost);
   if (err != cudaSuccess)
-  {
-    set_cuda_error(err);
-    return LIBREDIFFUSION_ERROR_CUDA_ERROR;
-  }
+    return report_cuda_failure(err);
   return LIBREDIFFUSION_SUCCESS;
 }
 
@@ -1738,10 +1743,7 @@ librediffusion_cuda_device_synchronize(void)
 {
   cudaError_t err = cudaDeviceSynchronize();
   if (err != cudaSuccess)
-  {
-    set_cuda_error(err);
-    return LIBREDIFFUSION_ERROR_CUDA_ERROR;
-  }
+    return report_cuda_failure(err);
   return LIBREDIFFUSION_SUCCESS;
 }
 

--- a/src/librediffusion_c.cpp
+++ b/src/librediffusion_c.cpp
@@ -30,14 +30,8 @@
 #define LIBREDIFFUSION_VERSION_PATCH 0
 #define LIBREDIFFUSION_VERSION_STRING "1.0.0"
 
-/* Handle validation (L-11, S-03).
- *
- * A C handle is the one thing a host cannot check for itself, so the library has to: passing a
- * destroyed handle, destroying twice, and using the out-parameter a failed create never wrote all
- * have to become ordinary error codes rather than a glibc double-free abort or a SIGSEGV.
- *
- * The check therefore lives OUTSIDE the block it validates. A registry of live handles is consulted
- * by pointer value and never dereferences an untrusted handle. */
+/* Handle validation: a registry of live handles, consulted by pointer value. The check must live
+ * OUTSIDE the block it validates, so an untrusted (possibly freed) handle is never dereferenced. */
 
 struct librediffusion_config_t
 {
@@ -59,7 +53,7 @@ struct handle_registry
 };
 
 // Deliberately leaked: a host may destroy a handle from a static destructor of its own, which can
-// run after any function-local static would have been torn down.
+// run after a function-local static would have been torn down.
 template <typename T>
 handle_registry<T>& registry()
 {
@@ -116,8 +110,8 @@ using librediffusion::drain_cuda_error;
 using librediffusion::g_last_cuda_error;
 using librediffusion::set_cuda_error;
 
-// For the entry points that hold a cudaError_t of their own: record it, consume whatever the runtime
-// still has pending, and answer with the right one of the two codes.
+// For entry points holding a cudaError_t of their own: record it, consume whatever is still pending,
+// and answer with the right one of the two codes.
 librediffusion_error_t report_cuda_failure(cudaError_t err)
 {
   drain_cuda_error();
@@ -169,18 +163,10 @@ librediffusion_error_t try_catch_wrapper(Func&& func)
   }
 }
 
-// Same as try_catch_wrapper, but WITHOUT the trailing check_cuda_error().
-//
-// L-13: cudaGetLastError() BRINGS UP the CUDA primary context. Wrapping the config entry points —
-// which allocate a struct of ints and strings and touch no device — in try_catch_wrapper therefore
-// made librediffusion_config_create() cost a full context creation (hundreds of ms, hundreds of MB
-// of VRAM) on whatever thread happened to deserialise a preset, pinned it to the DEFAULT device
-// before config_set_device was ever read, and left the process unable to fork a working child.
-// Measured: a child forked after version() can cudaMalloc; a child forked after config_create()
-// cannot (cudaErrorInitializationError).
-//
-// Use this for any entry point that cannot possibly have produced a CUDA error; keep
-// try_catch_wrapper where a CUDA call really may have happened.
+// Same as try_catch_wrapper, but WITHOUT the trailing check_cuda_error(): cudaGetLastError() BRINGS
+// UP the CUDA primary context, so wrapping an entry point that touches no device in it would cost a
+// full context creation on the calling thread, on the default device. Use this for any entry point
+// that cannot possibly have produced a CUDA error.
 template <typename Func>
 librediffusion_error_t try_catch_host(Func&& func)
 {
@@ -206,10 +192,8 @@ librediffusion_error_t try_catch_host(Func&& func)
   }
 }
 
-// Guard every inference entry point against a pipeline whose conditioning / scheduler the host has
-// not supplied yet. Construction succeeds long before prepare_embeds()/prepare_scheduler() are
-// called, and the denoise path dereferences both unconditionally, so an early frame used to be a
-// guaranteed null-deref rather than an error code. Returns SUCCESS when the pipeline is ready.
+// Construction succeeds long before prepare_embeds()/prepare_scheduler() are called, and the denoise
+// path dereferences both unconditionally. Returns SUCCESS when the pipeline is ready.
 librediffusion_error_t check_inference_ready(librediffusion_pipeline_handle pipeline)
 {
   if (const char* why = pipeline->cpp_pipeline->inference_readiness())
@@ -219,12 +203,9 @@ librediffusion_error_t check_inference_ready(librediffusion_pipeline_handle pipe
   }
   return LIBREDIFFUSION_SUCCESS;
 }
-// Reject a prepare_* / token call whose DECLARED shape disagrees with the pipeline's configured text
-// geometry (L-06). These entry points size the device buffer from the CALL's arguments, but every
-// consumer reads config_.text_seq_len * config_.text_hidden_dim back out of it with a raw
-// cudaMemcpyAsync — so a smaller declared shape is an out-of-bounds DEVICE read that surfaces later,
-// somewhere else, as an opaque cudaErrorInvalidDevice, after the output buffer has already been
-// partially written.
+// These entry points size the device buffer from the CALL's arguments, but every consumer reads
+// config_.text_seq_len * config_.text_hidden_dim back out of it with a raw cudaMemcpyAsync — so a
+// declared shape that disagrees with the config is an out-of-bounds DEVICE read.
 librediffusion_error_t check_text_dims(
     librediffusion_pipeline_handle pipeline, int seq_len, int hidden_dim, const char* what)
 {
@@ -288,8 +269,7 @@ librediffusion_config_create(librediffusion_config_handle* config)
 LIBREDIFFUSION_API void LIBREDIFFUSION_CALL
 librediffusion_config_destroy(librediffusion_config_handle config)
 {
-  // NULL is documented as safe; so is a handle that was already destroyed (previously a glibc
-  // "double free detected" -> SIGABRT).
+  // NULL is documented as safe; so is a handle that was already destroyed.
   if (!config || !unregister_handle(config))
     return;
   delete config;
@@ -357,15 +337,8 @@ librediffusion_config_set_dimensions(
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   if (width <= 0 || height <= 0 || latent_width <= 0 || latent_height <= 0)
     return LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS;
-  // Everything that is not <= 0 used to be accepted verbatim, including combinations that cannot
-  // describe a real image: 185600x185600 (batch*4*lh*lw overflows the int it is computed in ->
-  // negative -> a huge size_t -> a cudaMalloc that fails and whose result is never checked), 513x511
-  // (the VAE's 8x downsampling cannot express it), and a latent grid unrelated to the pixel grid
-  // (every kernel indexes one and the engine the other). Downstream those were contained only by
-  // luck. Refuse them here, where the caller still has a return code to look at.
-  //
-  // 16384 is well past any diffusion model in existence and keeps every width*height*4 and
-  // batch*4*lh*lw product far inside an int.
+  // Every kernel indexes the pixel grid and the engine the latent one, so they must agree; and
+  // 16384 keeps every width*height*4 and batch*4*lh*lw product (computed in int) from overflowing.
   constexpr int kMaxDim = 16384;
   if (width > kMaxDim || height > kMaxDim)
     return LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS;
@@ -609,10 +582,8 @@ librediffusion_config_set_temporal_params(
 {
   if (!valid(config))
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
-  // cache_interval is the divisor of `frame_id % cache_interval` on the img2img path — an integer
-  // division, so 0 is a SIGFPE that no try/catch can intercept. cache_maxframes is compared against
-  // a size_t, so a negative value becomes SIZE_MAX and the cache deque never drops a frame: one
-  // latent of VRAM per frame, forever. Both used to be stored verbatim.
+  // cache_interval divides `frame_id % cache_interval` on the img2img path — an integer division, so
+  // 0 is an uncatchable SIGFPE. cache_maxframes is compared against a size_t: negative = SIZE_MAX.
   if (cache_interval < 1 || cache_maxframes < 1)
     return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
 
@@ -684,11 +655,8 @@ librediffusion_pipeline_create(
   if (!valid(config) || !pipeline)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
 
-  // ALWAYS write the out-parameter. It used to be left untouched on failure, so a host that checks
-  // the handle rather than the return code (or reuses an uninitialised local) carried a wild
-  // pointer into every later call — each of which dereferenced it inside its own `!pipeline` guard.
-  // The wrapper was leaked on failure too: the throw escaped before `*pipeline = p`, and nothing
-  // owned `p`.
+  // ALWAYS write the out-parameter, so a host that checks the handle rather than the return code
+  // does not carry an uninitialised local into every later call.
   *pipeline = nullptr;
 
   return try_catch_wrapper([&]() {
@@ -703,9 +671,8 @@ librediffusion_pipeline_create(
 LIBREDIFFUSION_API void LIBREDIFFUSION_CALL
 librediffusion_pipeline_destroy(librediffusion_pipeline_handle pipeline)
 {
-  // NULL and already-destroyed are both no-ops (a second destroy used to re-run the whole dtor
-  // chain — CUDA stream, graph, TensorRT contexts — on freed memory, i.e. SIGSEGV). Registration is
-  // not conditional on cpp_pipeline: a pipeline whose construction failed still owns the wrapper.
+  // NULL and already-destroyed are both no-ops. Registration is not conditional on cpp_pipeline: a
+  // pipeline whose construction failed still owns the wrapper.
   if (!pipeline || !unregister_handle(pipeline))
     return;
   delete pipeline;
@@ -940,9 +907,8 @@ librediffusion_prepare_sdxl_conditioning(
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!text_embeds || !time_ids)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
-  // No shapes are passed here: both buffers are read using the pipeline's OWN configured dimensions.
-  // The least we can do is refuse the call on a pipeline that has no SDXL conditioning to fill, where
-  // the dimensions are meaningless and the copy would be sized from stale defaults.
+  // No shapes are passed here: both buffers are read at the pipeline's OWN configured dimensions, so
+  // on a pipeline with no SDXL conditioning the copy would be sized from stale defaults.
   {
     const auto& cfg = pipeline->cpp_pipeline->config();
     if (cfg.pooled_embedding_dim <= 0 || cfg.time_ids_dim <= 0)
@@ -1094,9 +1060,8 @@ librediffusion_set_ipadapter_tokens(
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   if (num_tokens <= 0 || dim <= 0)
     return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
-  // Same class as L-06: the token buffer is sized num_tokens*dim from these arguments, but the
-  // extended-ehs assembly reads ipadapter_num_tokens_ * config_.text_hidden_dim back out of it. A
-  // `dim` that is not the pipeline's cross-attention width is an out-of-bounds device read.
+  // The token buffer is sized num_tokens*dim from these arguments, but the extended-ehs assembly
+  // reads ipadapter_num_tokens_ * config_.text_hidden_dim back out of it.
   if (dim != pipeline->cpp_pipeline->config().text_hidden_dim)
   {
     std::fprintf(
@@ -1510,8 +1475,7 @@ librediffusion_enable_temporal_coherence(
 {
   if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
-  // See config_set_temporal_params: cache_interval == 0 is a SIGFPE on the next img2img, and a
-  // negative cache_maxframes reads as SIZE_MAX, i.e. "cache every frame forever".
+  // See config_set_temporal_params.
   if (cache_interval < 1 || max_cached_frames < 1)
     return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
 

--- a/src/librediffusion_c.cpp
+++ b/src/librediffusion_c.cpp
@@ -359,8 +359,9 @@ librediffusion_config_set_dimensions(
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   if (width <= 0 || height <= 0 || latent_width <= 0 || latent_height <= 0)
     return LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS;
-  // Every kernel indexes the pixel grid and the engine the latent one, so they must agree; and
-  // 16384 keeps every width*height*4 and batch*4*lh*lw product (computed in int) from overflowing.
+  // Every kernel indexes the pixel grid and the engine the latent one, so they must agree; 16384
+  // keeps width*height*4 inside an int. It does NOT bound batch*4*lh*lw — that depends on the batch
+  // counters, which are checked against the latent extent in init_buffers().
   constexpr int kMaxDim = 16384;
   if (width > kMaxDim || height > kMaxDim)
     return LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS;

--- a/src/librediffusion_c.cpp
+++ b/src/librediffusion_c.cpp
@@ -25,15 +25,52 @@
 #define LIBREDIFFUSION_VERSION_PATCH 0
 #define LIBREDIFFUSION_VERSION_STRING "1.0.0"
 
+/* Handle validation (L-11).
+ *
+ * A C handle is the one thing a host cannot check for itself, so the library has to. Each handle
+ * carries a magic word that is set on construction and CLEARED just before the block is freed, and
+ * every entry point checks it. That turns the three mistakes hosts actually make — passing a
+ * destroyed handle, destroying twice, and using the out-parameter a failed create never wrote —
+ * into ordinary error codes instead of a glibc double-free abort, a SIGSEGV, or (worst of all) a
+ * destroyed handle that keeps answering queries with garbage.
+ *
+ * Reading the magic out of a freed block is not something the standard blesses, but it is the only
+ * mitigation available at a C boundary and it converts the overwhelmingly common cases (the block
+ * is still mapped and either untouched or reused) into a clean rejection. */
+#define LIBREDIFFUSION_CONFIG_MAGIC 0x4C524443u   /* 'LRDC' */
+#define LIBREDIFFUSION_PIPELINE_MAGIC 0x4C524450u /* 'LRDP' */
+
 struct librediffusion_config_t
 {
+  unsigned int magic{LIBREDIFFUSION_CONFIG_MAGIC};
   librediffusion::LibreDiffusionConfig cpp_config;
 };
 
 struct librediffusion_pipeline_t
 {
+  unsigned int magic{LIBREDIFFUSION_PIPELINE_MAGIC};
   std::unique_ptr<librediffusion::LibreDiffusionPipeline> cpp_pipeline;
 };
+
+namespace
+{
+// A live, never-destroyed config handle.
+inline bool valid(librediffusion_config_handle c)
+{
+  return c && c->magic == LIBREDIFFUSION_CONFIG_MAGIC;
+}
+// A live pipeline handle that also owns a pipeline (i.e. usable for real work).
+inline bool valid(librediffusion_pipeline_handle p)
+{
+  return p && p->magic == LIBREDIFFUSION_PIPELINE_MAGIC && p->cpp_pipeline;
+}
+// A live pipeline handle, whether or not construction got as far as the pipeline itself. Only
+// destroy needs this weaker form.
+inline bool valid_handle(librediffusion_pipeline_handle p)
+{
+  return p && p->magic == LIBREDIFFUSION_PIPELINE_MAGIC;
+}
+} // anonymous namespace
 
 /*===========================================================================*/
 /* Thread-Local Error State                                                  */
@@ -135,6 +172,7 @@ librediffusion_config_create(librediffusion_config_handle* config)
 {
   if (!config)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
+  *config = nullptr;
 
   return try_catch_wrapper([&]() { *config = new librediffusion_config_t{}; });
 }
@@ -142,6 +180,12 @@ librediffusion_config_create(librediffusion_config_handle* config)
 LIBREDIFFUSION_API void LIBREDIFFUSION_CALL
 librediffusion_config_destroy(librediffusion_config_handle config)
 {
+  // NULL is documented as safe; so, now, is a handle that was already destroyed (previously a
+  // glibc "double free detected" -> SIGABRT). Clear the magic BEFORE freeing so the block cannot
+  // pass validation again even if the allocator hands it straight back out.
+  if (!valid(config))
+    return;
+  config->magic = 0;
   delete config;
 }
 
@@ -149,17 +193,19 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_config_clone(
     librediffusion_config_handle src, librediffusion_config_handle* dst)
 {
-  if (!src || !dst)
+  if (!valid(src) || !dst)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
+  *dst = nullptr;
 
-  return try_catch_wrapper(
-      [&]() { *dst = new librediffusion_config_t{src->cpp_config}; });
+  return try_catch_wrapper([&]() {
+    *dst = new librediffusion_config_t{LIBREDIFFUSION_CONFIG_MAGIC, src->cpp_config};
+  });
 }
 
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_config_set_device(librediffusion_config_handle config, int device)
 {
-  if (!config)
+  if (!valid(config))
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   config->cpp_config.device = device;
   return LIBREDIFFUSION_SUCCESS;
@@ -169,7 +215,7 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_config_set_model_type(
     librediffusion_config_handle config, librediffusion_model_type_t type)
 {
-  if (!config)
+  if (!valid(config))
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
 
   switch (type)
@@ -199,7 +245,7 @@ librediffusion_config_set_dimensions(
     librediffusion_config_handle config, int width, int height, int latent_width,
     int latent_height)
 {
-  if (!config)
+  if (!valid(config))
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   if (width <= 0 || height <= 0 || latent_width <= 0 || latent_height <= 0)
     return LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS;
@@ -214,7 +260,7 @@ librediffusion_config_set_dimensions(
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_config_set_batch_size(librediffusion_config_handle config, int batch_size)
 {
-  if (!config)
+  if (!valid(config))
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   if (batch_size <= 0)
     return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
@@ -225,7 +271,7 @@ librediffusion_config_set_batch_size(librediffusion_config_handle config, int ba
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_config_set_denoising_steps(librediffusion_config_handle config, int steps)
 {
-  if (!config)
+  if (!valid(config))
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   if (steps <= 0)
     return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
@@ -237,7 +283,7 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_config_set_frame_buffer_size(
     librediffusion_config_handle config, int size)
 {
-  if (!config)
+  if (!valid(config))
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   if (size <= 0)
     return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
@@ -249,7 +295,7 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_config_set_guidance_scale(
     librediffusion_config_handle config, float scale)
 {
-  if (!config)
+  if (!valid(config))
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   config->cpp_config.guidance_scale = scale;
   return LIBREDIFFUSION_SUCCESS;
@@ -258,7 +304,7 @@ librediffusion_config_set_guidance_scale(
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_config_set_delta(librediffusion_config_handle config, float delta)
 {
-  if (!config)
+  if (!valid(config))
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   config->cpp_config.delta = delta;
   return LIBREDIFFUSION_SUCCESS;
@@ -267,7 +313,7 @@ librediffusion_config_set_delta(librediffusion_config_handle config, float delta
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_config_set_add_noise(librediffusion_config_handle config, int enabled)
 {
-  if (!config)
+  if (!valid(config))
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   config->cpp_config.do_add_noise = (enabled != 0);
   return LIBREDIFFUSION_SUCCESS;
@@ -277,7 +323,7 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_config_set_denoising_batch(
     librediffusion_config_handle config, int enabled)
 {
-  if (!config)
+  if (!valid(config))
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   config->cpp_config.use_denoising_batch = (enabled != 0);
   return LIBREDIFFUSION_SUCCESS;
@@ -286,7 +332,7 @@ librediffusion_config_set_denoising_batch(
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_config_set_cuda_graph(librediffusion_config_handle config, int enabled)
 {
-  if (!config)
+  if (!valid(config))
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   config->cpp_config.use_cuda_graph = (enabled != 0);
   return LIBREDIFFUSION_SUCCESS;
@@ -295,7 +341,7 @@ librediffusion_config_set_cuda_graph(librediffusion_config_handle config, int en
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_config_set_seed(librediffusion_config_handle config, uint64_t seed)
 {
-  if (!config)
+  if (!valid(config))
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   config->cpp_config.seed = seed;
   return LIBREDIFFUSION_SUCCESS;
@@ -305,7 +351,7 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_config_set_cfg_type(
     librediffusion_config_handle config, librediffusion_cfg_type_t type)
 {
-  if (!config)
+  if (!valid(config))
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   config->cpp_config.cfg_type = static_cast<int>(type);
   return LIBREDIFFUSION_SUCCESS;
@@ -315,7 +361,7 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_config_set_text_config(
     librediffusion_config_handle config, int seq_len, int hidden_dim, int pad_token)
 {
-  if (!config)
+  if (!valid(config))
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   if (seq_len <= 0 || hidden_dim <= 0)
     return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
@@ -330,7 +376,7 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_config_set_sdxl_config(
     librediffusion_config_handle config, int pooled_embedding_dim, int time_ids_dim)
 {
-  if (!config)
+  if (!valid(config))
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   if (pooled_embedding_dim <= 0 || time_ids_dim <= 0)
     return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
@@ -344,7 +390,7 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_config_set_unet_engine(
     librediffusion_config_handle config, const char* path)
 {
-  if (!config || !path)
+  if (!valid(config) || !path)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
 
   return try_catch_wrapper([&]() {
@@ -356,7 +402,7 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_config_set_vae_encoder(
     librediffusion_config_handle config, const char* path)
 {
-  if (!config || !path)
+  if (!valid(config) || !path)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
 
   return try_catch_wrapper([&]() {
@@ -368,7 +414,7 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_config_set_vae_decoder(
     librediffusion_config_handle config, const char* path)
 {
-  if (!config || !path)
+  if (!valid(config) || !path)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
 
   return try_catch_wrapper([&]() {
@@ -382,7 +428,7 @@ librediffusion_config_add_controlnet(
 {
   // Returns the new ControlNet index (>=0), or -1 on error. Preprocessing is EXTERNAL: feed each
   // net's control image per-frame via librediffusion_set_controlnet_cond[_rgba](pipe, index, ...).
-  if (!config || !engine_path)
+  if (!valid(config) || !engine_path)
     return -1;
   try
   {
@@ -400,7 +446,7 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_config_set_timestep_indices(
     librediffusion_config_handle config, const int* indices, size_t count)
 {
-  if (!config)
+  if (!valid(config))
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   if (count > 0 && !indices)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
@@ -414,7 +460,7 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_config_set_pipeline_mode(
     librediffusion_config_handle config, librediffusion_pipeline_mode_t mode)
 {
-  if (!config)
+  if (!valid(config))
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
 
   switch (mode)
@@ -437,7 +483,7 @@ librediffusion_config_set_temporal_params(
     float injection_strength, float similarity_threshold, int cache_interval,
     int cache_maxframes)
 {
-  if (!config)
+  if (!valid(config))
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
 
   config->cpp_config.use_cached_attn = (use_cached_attn != 0);
@@ -453,7 +499,7 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_config_set_tome(
     librediffusion_config_handle config, int enabled, float ratio)
 {
-  if (!config)
+  if (!valid(config))
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
 
   config->cpp_config.use_tome_cache = (enabled != 0);
@@ -464,37 +510,37 @@ librediffusion_config_set_tome(
 LIBREDIFFUSION_API int LIBREDIFFUSION_CALL
 librediffusion_config_get_width(librediffusion_config_handle config)
 {
-  return config ? config->cpp_config.width : 0;
+  return valid(config) ? config->cpp_config.width : 0;
 }
 
 LIBREDIFFUSION_API int LIBREDIFFUSION_CALL
 librediffusion_config_get_height(librediffusion_config_handle config)
 {
-  return config ? config->cpp_config.height : 0;
+  return valid(config) ? config->cpp_config.height : 0;
 }
 
 LIBREDIFFUSION_API int LIBREDIFFUSION_CALL
 librediffusion_config_get_latent_width(librediffusion_config_handle config)
 {
-  return config ? config->cpp_config.latent_width : 0;
+  return valid(config) ? config->cpp_config.latent_width : 0;
 }
 
 LIBREDIFFUSION_API int LIBREDIFFUSION_CALL
 librediffusion_config_get_latent_height(librediffusion_config_handle config)
 {
-  return config ? config->cpp_config.latent_height : 0;
+  return valid(config) ? config->cpp_config.latent_height : 0;
 }
 
 LIBREDIFFUSION_API int LIBREDIFFUSION_CALL
 librediffusion_config_get_batch_size(librediffusion_config_handle config)
 {
-  return config ? config->cpp_config.batch_size : 0;
+  return valid(config) ? config->cpp_config.batch_size : 0;
 }
 
 LIBREDIFFUSION_API int LIBREDIFFUSION_CALL
 librediffusion_config_get_denoising_steps(librediffusion_config_handle config)
 {
-  return config ? config->cpp_config.denoising_steps : 0;
+  return valid(config) ? config->cpp_config.denoising_steps : 0;
 }
 
 /*===========================================================================*/
@@ -505,20 +551,34 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_pipeline_create(
     librediffusion_config_handle config, librediffusion_pipeline_handle* pipeline)
 {
-  if (!config || !pipeline)
+  if (!valid(config) || !pipeline)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
 
+  // ALWAYS write the out-parameter. It used to be left untouched on failure, so a host that checks
+  // the handle rather than the return code (or reuses an uninitialised local) carried a wild
+  // pointer into every later call — each of which dereferenced it inside its own `!pipeline` guard.
+  // The wrapper was leaked on failure too: the throw escaped before `*pipeline = p`, and nothing
+  // owned `p`.
+  *pipeline = nullptr;
+
   return try_catch_wrapper([&]() {
-    auto p = new librediffusion_pipeline_t{};
+    auto p = std::make_unique<librediffusion_pipeline_t>();
     p->cpp_pipeline = std::make_unique<librediffusion::LibreDiffusionPipeline>(
         config->cpp_config);
-    *pipeline = p;
+    *pipeline = p.release();
   });
 }
 
 LIBREDIFFUSION_API void LIBREDIFFUSION_CALL
 librediffusion_pipeline_destroy(librediffusion_pipeline_handle pipeline)
 {
+  // NULL and already-destroyed are both no-ops (a second destroy used to re-run the whole dtor
+  // chain — CUDA stream, graph, TensorRT contexts — on freed memory, i.e. SIGSEGV). valid_handle()
+  // rather than valid(): a pipeline whose construction failed has no cpp_pipeline but still owns
+  // the wrapper, and must still be freed.
+  if (!valid_handle(pipeline))
+    return;
+  pipeline->magic = 0;
   delete pipeline;
 }
 
@@ -562,7 +622,7 @@ librediffusion_engine_cache_set_max_entries(unsigned long long max_entries)
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_pipeline_init_cuda(librediffusion_pipeline_handle pipeline)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
 
   return try_catch_wrapper([&]() {
@@ -573,7 +633,7 @@ librediffusion_pipeline_init_cuda(librediffusion_pipeline_handle pipeline)
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_pipeline_init_npp(librediffusion_pipeline_handle pipeline)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
 
   return try_catch_wrapper([&]() {
@@ -584,7 +644,7 @@ librediffusion_pipeline_init_npp(librediffusion_pipeline_handle pipeline)
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_pipeline_init_engines(librediffusion_pipeline_handle pipeline)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
 
   return try_catch_wrapper([&]() {
@@ -595,7 +655,7 @@ librediffusion_pipeline_init_engines(librediffusion_pipeline_handle pipeline)
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_pipeline_init_buffers(librediffusion_pipeline_handle pipeline)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
 
   return try_catch_wrapper([&]() {
@@ -628,9 +688,9 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_pipeline_reinit_buffers(
     librediffusion_pipeline_handle pipeline, librediffusion_config_handle config)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
-  if (!config)
+  if (!valid(config))
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
 
   return try_catch_wrapper([&]() {
@@ -647,7 +707,7 @@ librediffusion_prepare_embeds(
     librediffusion_pipeline_handle pipeline, const librediffusion_half_t* prompt_embeds,
     int seq_len, int hidden_dim)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!prompt_embeds)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
@@ -665,7 +725,7 @@ librediffusion_prepare_null_embeds(
     librediffusion_pipeline_handle pipeline, const librediffusion_half_t* null_embeds,
     int seq_len, int hidden_dim)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!null_embeds)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
@@ -683,7 +743,7 @@ librediffusion_prepare_negative_embeds(
     librediffusion_pipeline_handle pipeline,
     const librediffusion_half_t* negative_embeds, int seq_len, int hidden_dim)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!negative_embeds)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
@@ -702,7 +762,7 @@ librediffusion_blend_embeds(
     const librediffusion_half_t* const* embeddings, const float* weights,
     int num_embeddings, int seq_len, int hidden_dim)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!embeddings || !weights)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
@@ -726,7 +786,7 @@ librediffusion_prepare_sdxl_conditioning(
     librediffusion_pipeline_handle pipeline, const librediffusion_half_t* text_embeds,
     const librediffusion_half_t* time_ids)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!text_embeds || !time_ids)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
@@ -743,7 +803,7 @@ librediffusion_prepare_scheduler(
     const float* alpha_prod_t_sqrt, const float* beta_prod_t_sqrt, const float* c_skip,
     const float* c_out, size_t num_timesteps)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!timesteps || !alpha_prod_t_sqrt || !beta_prod_t_sqrt || !c_skip || !c_out)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
@@ -766,7 +826,7 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_set_init_noise(
     librediffusion_pipeline_handle pipeline, const librediffusion_half_t* noise)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!noise)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
@@ -781,7 +841,7 @@ librediffusion_set_controlnet_cond(
     librediffusion_pipeline_handle pipeline, int index, const librediffusion_half_t* cond,
     int img_height, int img_width)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!cond)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
@@ -795,7 +855,7 @@ librediffusion_set_controlnet_cond_rgba(
     librediffusion_pipeline_handle pipeline, int index, const uint8_t* cpu_rgba,
     int img_height, int img_width)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!cpu_rgba)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
@@ -808,7 +868,7 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_set_controlnet_scale(
     librediffusion_pipeline_handle pipeline, int index, float scale)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   return try_catch_wrapper([&]() {
     pipeline->cpp_pipeline->set_controlnet_scale(index, scale);
@@ -820,7 +880,7 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_config_set_ipadapter(
     librediffusion_config_handle config, int num_image_tokens, float scale)
 {
-  if (!config)
+  if (!valid(config))
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   return try_catch_wrapper([&]() {
     config->cpp_config.ipadapter_num_tokens = num_image_tokens;
@@ -833,7 +893,7 @@ librediffusion_config_set_ipadapter_image_encoder(
     librediffusion_config_handle config, const char* image_encoder_engine,
     const char* image_proj_engine)
 {
-  if (!config)
+  if (!valid(config))
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   if (!image_encoder_engine || !image_proj_engine)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
@@ -848,7 +908,7 @@ librediffusion_set_ipadapter_image(
     librediffusion_pipeline_handle pipeline, const uint8_t* cpu_rgba, int img_height,
     int img_width)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!cpu_rgba)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
@@ -862,7 +922,7 @@ librediffusion_set_ipadapter_tokens(
     librediffusion_pipeline_handle pipeline, const librediffusion_half_t* pos_tokens,
     const librediffusion_half_t* neg_tokens, int num_tokens, int dim)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!pos_tokens)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
@@ -875,7 +935,7 @@ librediffusion_set_ipadapter_tokens(
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_set_ipadapter_scale(librediffusion_pipeline_handle pipeline, float scale)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   return try_catch_wrapper([&]() { pipeline->cpp_pipeline->set_ipadapter_scale(scale); });
 }
@@ -884,7 +944,7 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_set_ipadapter_scale_vector(
     librediffusion_pipeline_handle pipeline, const float* per_layer, int num_ip_layers)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!per_layer)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
@@ -896,7 +956,7 @@ librediffusion_set_ipadapter_scale_vector(
 LIBREDIFFUSION_API int LIBREDIFFUSION_CALL
 librediffusion_num_runtime_loras(librediffusion_pipeline_handle pipeline)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return 0;
   return pipeline->cpp_pipeline->num_runtime_loras();
 }
@@ -904,7 +964,7 @@ librediffusion_num_runtime_loras(librediffusion_pipeline_handle pipeline)
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_set_lora_scale(librediffusion_pipeline_handle pipeline, int idx, float scale)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   return try_catch_wrapper([&]() { pipeline->cpp_pipeline->set_lora_scale(idx, scale); });
 }
@@ -913,7 +973,7 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_set_lora_scale_vector(
     librediffusion_pipeline_handle pipeline, const float* scales, int n)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!scales)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
@@ -923,7 +983,7 @@ librediffusion_set_lora_scale_vector(
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_reseed(librediffusion_pipeline_handle pipeline, int64_t seed)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
 
   return try_catch_wrapper([&]() {
@@ -935,7 +995,7 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_set_guidance_scale(
     librediffusion_pipeline_handle pipeline, float guidance)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
 
   return try_catch_wrapper([&]() {
@@ -946,7 +1006,7 @@ librediffusion_set_guidance_scale(
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_set_delta(librediffusion_pipeline_handle pipeline, float delta)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
 
   return try_catch_wrapper([&]() {
@@ -962,7 +1022,7 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL librediffusion_img
     librediffusion_pipeline_handle pipeline, const uint8_t* cpu_rgba_input,
     uint8_t* cpu_rgba_output, int width, int height)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!cpu_rgba_input || !cpu_rgba_output)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
@@ -981,7 +1041,7 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL librediffusion_txt
     librediffusion_pipeline_handle pipeline, uint8_t* cpu_rgba_output, int width,
     int height)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!cpu_rgba_output)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
@@ -1005,7 +1065,7 @@ librediffusion_img2img_gpu_half(
     librediffusion_pipeline_handle pipeline, const librediffusion_half_t* image_in,
     librediffusion_half_t* image_out, librediffusion_stream_t stream)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!image_in || !image_out)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
@@ -1026,7 +1086,7 @@ librediffusion_img2img_gpu_float(
     librediffusion_pipeline_handle pipeline, const float* image_in,
     librediffusion_half_t* image_out, librediffusion_stream_t stream)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!image_in || !image_out)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
@@ -1046,7 +1106,7 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL librediffusion_txt
     librediffusion_pipeline_handle pipeline, librediffusion_half_t* image_out,
     librediffusion_stream_t stream)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!image_out)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
@@ -1066,7 +1126,7 @@ librediffusion_txt2img_sd_turbo_gpu(
     librediffusion_pipeline_handle pipeline, librediffusion_half_t* image_out,
     librediffusion_stream_t stream)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!image_out)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
@@ -1089,7 +1149,7 @@ librediffusion_encode_image_half(
     librediffusion_pipeline_handle pipeline, const librediffusion_half_t* image,
     librediffusion_half_t* latent_out, librediffusion_stream_t stream)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!image || !latent_out)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
@@ -1107,7 +1167,7 @@ librediffusion_encode_image_float(
     librediffusion_pipeline_handle pipeline, const float* image,
     librediffusion_half_t* latent_out, librediffusion_stream_t stream)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!image || !latent_out)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
@@ -1125,7 +1185,7 @@ librediffusion_decode_latent(
     librediffusion_pipeline_handle pipeline, const librediffusion_half_t* latent,
     librediffusion_half_t* image_out, librediffusion_stream_t stream)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!latent || !image_out)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
@@ -1147,7 +1207,7 @@ librediffusion_predict_x0_batch(
     librediffusion_pipeline_handle pipeline, const librediffusion_half_t* x_t_latent_in,
     librediffusion_half_t* x_0_pred_out, librediffusion_stream_t stream)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!x_t_latent_in || !x_0_pred_out)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
@@ -1172,7 +1232,7 @@ librediffusion_rgba_nhwc_to_nchw_float(
     librediffusion_pipeline_handle pipeline, const uint8_t* rgba_nhwc_in,
     float* rgb_nchw_out, int width, int height, librediffusion_stream_t stream)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!rgba_nhwc_in || !rgb_nchw_out)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
@@ -1191,7 +1251,7 @@ librediffusion_rgba_nhwc_to_nchw_half(
     librediffusion_half_t* rgb_nchw_out, int width, int height,
     librediffusion_stream_t stream)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!rgba_nhwc_in || !rgb_nchw_out)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
@@ -1209,7 +1269,7 @@ librediffusion_nchw_half_to_rgba_nhwc(
     librediffusion_pipeline_handle pipeline, const librediffusion_half_t* rgb_nchw_in,
     uint8_t* rgba_nhwc_out, int width, int height, librediffusion_stream_t stream)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!rgb_nchw_in || !rgba_nhwc_out)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
@@ -1227,7 +1287,7 @@ librediffusion_nchw_float_to_rgba_nhwc(
     librediffusion_pipeline_handle pipeline, const float* rgb_nchw_in,
     uint8_t* rgba_nhwc_out, int width, int height, librediffusion_stream_t stream)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!rgb_nchw_in || !rgba_nhwc_out)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
@@ -1244,7 +1304,7 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL librediffusion_rgb
     librediffusion_pipeline_handle pipeline, uint8_t* rgba_input, int in_width,
     int in_height, uint8_t* rgba_output, int out_width, int out_height)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!rgba_input || !rgba_output)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
@@ -1268,7 +1328,7 @@ librediffusion_enable_temporal_coherence(
     float injection_strength, float similarity_threshold, int cache_interval,
     int max_cached_frames)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
 
   return try_catch_wrapper([&]() {
@@ -1284,7 +1344,7 @@ librediffusion_enable_temporal_coherence(
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_disable_temporal_coherence(librediffusion_pipeline_handle pipeline)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
 
   return try_catch_wrapper([&]() {
@@ -1295,7 +1355,7 @@ librediffusion_disable_temporal_coherence(librediffusion_pipeline_handle pipelin
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_reset_temporal_state(librediffusion_pipeline_handle pipeline)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
 
   return try_catch_wrapper([&]() {
@@ -1306,7 +1366,7 @@ librediffusion_reset_temporal_state(librediffusion_pipeline_handle pipeline)
 LIBREDIFFUSION_API int LIBREDIFFUSION_CALL
 librediffusion_get_current_frame_id(librediffusion_pipeline_handle pipeline)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return -1;
 
   return pipeline->cpp_pipeline->getCurrentFrameId();
@@ -1439,7 +1499,7 @@ librediffusion_half_to_float(librediffusion_half_t value)
 LIBREDIFFUSION_API librediffusion_stream_t LIBREDIFFUSION_CALL
 librediffusion_pipeline_get_stream(librediffusion_pipeline_handle pipeline)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return nullptr;
 
   return static_cast<librediffusion_stream_t>(pipeline->cpp_pipeline->stream_);
@@ -1448,7 +1508,7 @@ librediffusion_pipeline_get_stream(librediffusion_pipeline_handle pipeline)
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_pipeline_synchronize(librediffusion_pipeline_handle pipeline)
 {
-  if (!pipeline || !pipeline->cpp_pipeline)
+  if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
 
   cudaError_t err = cudaStreamSynchronize(pipeline->cpp_pipeline->stream_);

--- a/src/librediffusion_c.cpp
+++ b/src/librediffusion_c.cpp
@@ -123,6 +123,43 @@ librediffusion_error_t try_catch_wrapper(Func&& func)
   }
 }
 
+// Same as try_catch_wrapper, but WITHOUT the trailing check_cuda_error().
+//
+// L-13: cudaGetLastError() BRINGS UP the CUDA primary context. Wrapping the config entry points —
+// which allocate a struct of ints and strings and touch no device — in try_catch_wrapper therefore
+// made librediffusion_config_create() cost a full context creation (hundreds of ms, hundreds of MB
+// of VRAM) on whatever thread happened to deserialise a preset, pinned it to the DEFAULT device
+// before config_set_device was ever read, and left the process unable to fork a working child.
+// Measured: a child forked after version() can cudaMalloc; a child forked after config_create()
+// cannot (cudaErrorInitializationError).
+//
+// Use this for any entry point that cannot possibly have produced a CUDA error; keep
+// try_catch_wrapper where a CUDA call really may have happened.
+template <typename Func>
+librediffusion_error_t try_catch_host(Func&& func)
+{
+  try
+  {
+    func();
+    return LIBREDIFFUSION_SUCCESS;
+  }
+  catch (const std::bad_alloc&)
+  {
+    std::fprintf(stderr, "[librediffusion] OUT_OF_MEMORY\n");
+    return LIBREDIFFUSION_ERROR_OUT_OF_MEMORY;
+  }
+  catch (const std::exception& e)
+  {
+    std::fprintf(stderr, "[librediffusion] INTERNAL ERROR: %s\n", e.what());
+    return LIBREDIFFUSION_ERROR_INTERNAL;
+  }
+  catch (...)
+  {
+    std::fprintf(stderr, "[librediffusion] INTERNAL ERROR: unknown (non-std::exception)\n");
+    return LIBREDIFFUSION_ERROR_INTERNAL;
+  }
+}
+
 // Guard every inference entry point against a pipeline whose conditioning / scheduler the host has
 // not supplied yet. Construction succeeds long before prepare_embeds()/prepare_scheduler() are
 // called, and the denoise path dereferences both unconditionally, so an early frame used to be a
@@ -195,7 +232,7 @@ librediffusion_config_create(librediffusion_config_handle* config)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   *config = nullptr;
 
-  return try_catch_wrapper([&]() { *config = new librediffusion_config_t{}; });
+  return try_catch_host([&]() { *config = new librediffusion_config_t{}; });
 }
 
 LIBREDIFFUSION_API void LIBREDIFFUSION_CALL
@@ -218,7 +255,7 @@ librediffusion_config_clone(
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   *dst = nullptr;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_host([&]() {
     *dst = new librediffusion_config_t{LIBREDIFFUSION_CONFIG_MAGIC, src->cpp_config};
   });
 }
@@ -414,7 +451,7 @@ librediffusion_config_set_unet_engine(
   if (!valid(config) || !path)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_host([&]() {
     config->cpp_config.unet_engine_path = path;
   });
 }
@@ -426,7 +463,7 @@ librediffusion_config_set_vae_encoder(
   if (!valid(config) || !path)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_host([&]() {
     config->cpp_config.vae_encoder_path = path;
   });
 }
@@ -438,7 +475,7 @@ librediffusion_config_set_vae_decoder(
   if (!valid(config) || !path)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_host([&]() {
     config->cpp_config.vae_decoder_path = path;
   });
 }
@@ -472,7 +509,7 @@ librediffusion_config_set_timestep_indices(
   if (count > 0 && !indices)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_host([&]() {
     config->cpp_config.timestep_indices.assign(indices, indices + count);
   });
 }
@@ -936,7 +973,7 @@ librediffusion_config_set_ipadapter(
 {
   if (!valid(config))
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
-  return try_catch_wrapper([&]() {
+  return try_catch_host([&]() {
     config->cpp_config.ipadapter_num_tokens = num_image_tokens;
     config->cpp_config.ipadapter_scale = scale;
   });
@@ -951,7 +988,7 @@ librediffusion_config_set_ipadapter_image_encoder(
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   if (!image_encoder_engine || !image_proj_engine)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
-  return try_catch_wrapper([&]() {
+  return try_catch_host([&]() {
     config->cpp_config.ipadapter_image_encoder_path = image_encoder_engine;
     config->cpp_config.ipadapter_image_proj_path = image_proj_engine;
   });

--- a/src/librediffusion_c.cpp
+++ b/src/librediffusion_c.cpp
@@ -307,6 +307,22 @@ librediffusion_config_set_dimensions(
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   if (width <= 0 || height <= 0 || latent_width <= 0 || latent_height <= 0)
     return LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS;
+  // Everything that is not <= 0 used to be accepted verbatim, including combinations that cannot
+  // describe a real image: 185600x185600 (batch*4*lh*lw overflows the int it is computed in ->
+  // negative -> a huge size_t -> a cudaMalloc that fails and whose result is never checked), 513x511
+  // (the VAE's 8x downsampling cannot express it), and a latent grid unrelated to the pixel grid
+  // (every kernel indexes one and the engine the other). Downstream those were contained only by
+  // luck. Refuse them here, where the caller still has a return code to look at.
+  //
+  // 16384 is well past any diffusion model in existence and keeps every width*height*4 and
+  // batch*4*lh*lw product far inside an int.
+  constexpr int kMaxDim = 16384;
+  if (width > kMaxDim || height > kMaxDim)
+    return LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS;
+  if ((width % 8) != 0 || (height % 8) != 0)
+    return LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS;
+  if (latent_width != width / 8 || latent_height != height / 8)
+    return LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS;
 
   config->cpp_config.width = width;
   config->cpp_config.height = height;

--- a/src/librediffusion_c.cpp
+++ b/src/librediffusion_c.cpp
@@ -215,6 +215,16 @@ librediffusion_error_t check_inference_ready(librediffusion_pipeline_handle pipe
   }
   return LIBREDIFFUSION_SUCCESS;
 }
+
+librediffusion_error_t check_ready(const char* why)
+{
+  if (why)
+  {
+    std::fprintf(stderr, "[librediffusion] NOT_INITIALIZED: %s\n", why);
+    return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
+  }
+  return LIBREDIFFUSION_SUCCESS;
+}
 // These entry points size the device buffer from the CALL's arguments, but every consumer reads
 // config_.text_seq_len * config_.text_hidden_dim back out of it with a raw cudaMemcpyAsync — so a
 // declared shape that disagrees with the config is an out-of-bounds DEVICE read.
@@ -1303,6 +1313,9 @@ librediffusion_encode_image_half(
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!image || !latent_out)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
+  if (librediffusion_error_t e = check_ready(pipeline->cpp_pipeline->encode_readiness());
+      e != LIBREDIFFUSION_SUCCESS)
+    return e;
 
   return try_catch_wrapper([&]() {
     pipeline->cpp_pipeline->encode_image(
@@ -1321,6 +1334,9 @@ librediffusion_encode_image_float(
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!image || !latent_out)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
+  if (librediffusion_error_t e = check_ready(pipeline->cpp_pipeline->encode_readiness());
+      e != LIBREDIFFUSION_SUCCESS)
+    return e;
 
   return try_catch_wrapper([&]() {
     pipeline->cpp_pipeline->encode_image(
@@ -1339,6 +1355,9 @@ librediffusion_decode_latent(
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!latent || !image_out)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
+  if (librediffusion_error_t e = check_ready(pipeline->cpp_pipeline->decode_readiness());
+      e != LIBREDIFFUSION_SUCCESS)
+    return e;
 
   return try_catch_wrapper([&]() {
     pipeline->cpp_pipeline->decode_latent(

--- a/src/librediffusion_c.cpp
+++ b/src/librediffusion_c.cpp
@@ -506,6 +506,12 @@ librediffusion_config_set_temporal_params(
 {
   if (!valid(config))
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
+  // cache_interval is the divisor of `frame_id % cache_interval` on the img2img path — an integer
+  // division, so 0 is a SIGFPE that no try/catch can intercept. cache_maxframes is compared against
+  // a size_t, so a negative value becomes SIZE_MAX and the cache deque never drops a frame: one
+  // latent of VRAM per frame, forever. Both used to be stored verbatim.
+  if (cache_interval < 1 || cache_maxframes < 1)
+    return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
 
   config->cpp_config.use_cached_attn = (use_cached_attn != 0);
   config->cpp_config.use_feature_injection = (use_feature_injection != 0);
@@ -1392,6 +1398,10 @@ librediffusion_enable_temporal_coherence(
 {
   if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
+  // See config_set_temporal_params: cache_interval == 0 is a SIGFPE on the next img2img, and a
+  // negative cache_maxframes reads as SIZE_MAX, i.e. "cache every frame forever".
+  if (cache_interval < 1 || max_cached_frames < 1)
+    return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
 
   return try_catch_wrapper([&]() {
     pipeline->cpp_pipeline->enableTemporalCoherence(

--- a/src/librediffusion_c.cpp
+++ b/src/librediffusion_c.cpp
@@ -976,6 +976,7 @@ librediffusion_config_set_ipadapter(
   return try_catch_host([&]() {
     config->cpp_config.ipadapter_num_tokens = num_image_tokens;
     config->cpp_config.ipadapter_scale = scale;
+    config->cpp_config.ipadapter_requested = true;
   });
 }
 

--- a/src/librediffusion_c.cpp
+++ b/src/librediffusion_c.cpp
@@ -801,18 +801,11 @@ librediffusion_pipeline_reinit_buffers(
   if (!valid(config))
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
 
-  bool rejected = false;
-  librediffusion_error_t err = try_catch_wrapper([&]() {
-    std::string why = pipeline->cpp_pipeline->geometry_rejection(config->cpp_config);
-    if(!why.empty())
-    {
-      std::fprintf(stderr, "[librediffusion] INVALID_DIMENSIONS: %s\n", why.c_str());
-      rejected = true;
-      return;
-    }
+  // reinit_buffers runs geometry_rejection itself and throws invalid_dimensions_error, which
+  // try_catch_wrapper turns into LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS.
+  return try_catch_wrapper([&]() {
     pipeline->cpp_pipeline->reinit_buffers(config->cpp_config);
   });
-  return rejected ? LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS : err;
 }
 
 /*===========================================================================*/

--- a/src/librediffusion_c.cpp
+++ b/src/librediffusion_c.cpp
@@ -147,6 +147,18 @@ librediffusion_error_t try_catch_wrapper(Func&& func)
     std::fprintf(stderr, "[librediffusion] OUT_OF_MEMORY\n");
     return LIBREDIFFUSION_ERROR_OUT_OF_MEMORY;
   }
+  catch (const librediffusion::invalid_dimensions_error& e)
+  {
+    drain_cuda_error();
+    std::fprintf(stderr, "[librediffusion] INVALID_DIMENSIONS: %s\n", e.what());
+    return LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS;
+  }
+  catch (const librediffusion::invalid_argument_error& e)
+  {
+    drain_cuda_error();
+    std::fprintf(stderr, "[librediffusion] INVALID_ARGUMENT: %s\n", e.what());
+    return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
+  }
   catch (const std::exception& e)
   {
     // Surface the message so the C-API caller (harness/app) can see WHY an internal error

--- a/src/librediffusion_c.cpp
+++ b/src/librediffusion_c.cpp
@@ -5,6 +5,7 @@
  * Compile this file with NVCC or a C++23 compiler that supports CUDA.
  */
 
+#include "device_guard.hpp"
 #include "librediffusion_c.h"
 #include "librediffusion.hpp"
 #include "tensorrt_wrappers.hpp"
@@ -41,6 +42,7 @@ struct librediffusion_config_t
 struct librediffusion_pipeline_t
 {
   std::unique_ptr<librediffusion::LibreDiffusionPipeline> cpp_pipeline;
+  int device{0};
 };
 
 namespace
@@ -129,6 +131,18 @@ librediffusion_error_t check_cuda_error()
     return LIBREDIFFUSION_SUCCESS;
   return cuda_error_is_context_fatal(err) ? LIBREDIFFUSION_ERROR_CUDA_CONTEXT_LOST
                                           : LIBREDIFFUSION_ERROR_CUDA_ERROR;
+}
+
+template <typename Func>
+librediffusion_error_t try_catch_wrapper(Func&& func);
+
+// Runs func with the current CUDA device scoped to the handle's. cudaSetDevice is thread state, so
+// without this a handle built on one thread and driven from another lands on that thread's default.
+template <typename Func>
+librediffusion_error_t try_catch_wrapper(int device, Func&& func)
+{
+  librediffusion::DeviceGuard guard{device};
+  return try_catch_wrapper(std::forward<Func>(func));
 }
 
 template <typename Func>
@@ -682,8 +696,13 @@ librediffusion_pipeline_create(
   // does not carry an uninitialised local into every later call.
   *pipeline = nullptr;
 
-  return try_catch_wrapper([&]() {
+  const int dev = librediffusion::resolve_device(config->cpp_config.device);
+  if (dev < 0)
+    return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
+
+  return try_catch_wrapper(dev, [&]() {
     auto p = std::make_unique<librediffusion_pipeline_t>();
+    p->device = dev;
     p->cpp_pipeline = std::make_unique<librediffusion::LibreDiffusionPipeline>(
         config->cpp_config);
     register_handle(p.get());
@@ -744,7 +763,7 @@ librediffusion_pipeline_init_cuda(librediffusion_pipeline_handle pipeline)
   if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->init_cuda();
   });
 }
@@ -755,7 +774,7 @@ librediffusion_pipeline_init_npp(librediffusion_pipeline_handle pipeline)
   if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->init_npp();
   });
 }
@@ -766,7 +785,7 @@ librediffusion_pipeline_init_engines(librediffusion_pipeline_handle pipeline)
   if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->init_engines();
   });
 }
@@ -777,7 +796,7 @@ librediffusion_pipeline_init_buffers(librediffusion_pipeline_handle pipeline)
   if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->init_buffers();
   });
 }
@@ -814,7 +833,7 @@ librediffusion_pipeline_reinit_buffers(
 
   // reinit_buffers runs geometry_rejection itself and throws invalid_dimensions_error, which
   // try_catch_wrapper turns into LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS.
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->reinit_buffers(config->cpp_config);
   });
 }
@@ -838,7 +857,7 @@ librediffusion_prepare_embeds(
       e != LIBREDIFFUSION_SUCCESS)
     return e;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->prepare_embeds(
         to_half_ptr(prompt_embeds), seq_len, hidden_dim);
   });
@@ -859,7 +878,7 @@ librediffusion_prepare_null_embeds(
       e != LIBREDIFFUSION_SUCCESS)
     return e;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->prepare_null_embeds(
         to_half_ptr(null_embeds), seq_len, hidden_dim);
   });
@@ -880,7 +899,7 @@ librediffusion_prepare_negative_embeds(
       e != LIBREDIFFUSION_SUCCESS)
     return e;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->prepare_negative_embeds(
         to_half_ptr(negative_embeds), seq_len, hidden_dim);
   });
@@ -902,7 +921,7 @@ librediffusion_blend_embeds(
       e != LIBREDIFFUSION_SUCCESS)
     return e;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     // Convert librediffusion_half_t* const* to __half* const*
     std::vector<const __half*> embed_ptrs(num_embeddings);
     for(int i = 0; i < num_embeddings; i++)
@@ -938,7 +957,7 @@ librediffusion_prepare_sdxl_conditioning(
     }
   }
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->prepare_sdxl_conditioning(
         to_half_ptr(text_embeds), to_half_ptr(time_ids));
   });
@@ -957,7 +976,7 @@ librediffusion_prepare_scheduler(
   if (num_timesteps == 0)
     return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     std::span<float> ts_span(const_cast<float*>(timesteps), num_timesteps);
     std::span<float> alpha_span(const_cast<float*>(alpha_prod_t_sqrt), num_timesteps);
     std::span<float> beta_span(const_cast<float*>(beta_prod_t_sqrt), num_timesteps);
@@ -978,7 +997,7 @@ librediffusion_set_init_noise(
   if (!noise)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->set_init_noise(to_half_ptr(noise));
   });
 }
@@ -992,7 +1011,7 @@ librediffusion_set_controlnet_cond(
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!cond)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->set_controlnet_cond(index, to_half_ptr(cond), img_height, img_width);
   });
 }
@@ -1006,7 +1025,7 @@ librediffusion_set_controlnet_cond_rgba(
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!cpu_rgba)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->set_controlnet_cond_rgba(index, cpu_rgba, img_height, img_width);
   });
 }
@@ -1017,7 +1036,7 @@ librediffusion_set_controlnet_scale(
 {
   if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->set_controlnet_scale(index, scale);
   });
 }
@@ -1060,7 +1079,7 @@ librediffusion_set_ipadapter_image(
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!cpu_rgba)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->set_ipadapter_image(cpu_rgba, img_height, img_width);
   });
 }
@@ -1087,7 +1106,7 @@ librediffusion_set_ipadapter_tokens(
         dim, pipeline->cpp_pipeline->config().text_hidden_dim);
     return LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS;
   }
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->set_ipadapter_tokens(
         to_half_ptr(pos_tokens), to_half_ptr(neg_tokens), num_tokens, dim);
   });
@@ -1098,7 +1117,7 @@ librediffusion_set_ipadapter_scale(librediffusion_pipeline_handle pipeline, floa
 {
   if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
-  return try_catch_wrapper([&]() { pipeline->cpp_pipeline->set_ipadapter_scale(scale); });
+  return try_catch_wrapper(pipeline->device, [&]() { pipeline->cpp_pipeline->set_ipadapter_scale(scale); });
 }
 
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
@@ -1109,7 +1128,7 @@ librediffusion_set_ipadapter_scale_vector(
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!per_layer)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->set_ipadapter_scale_vector(per_layer, num_ip_layers);
   });
 }
@@ -1127,7 +1146,7 @@ librediffusion_set_lora_scale(librediffusion_pipeline_handle pipeline, int idx, 
 {
   if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
-  return try_catch_wrapper([&]() { pipeline->cpp_pipeline->set_lora_scale(idx, scale); });
+  return try_catch_wrapper(pipeline->device, [&]() { pipeline->cpp_pipeline->set_lora_scale(idx, scale); });
 }
 
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
@@ -1138,7 +1157,7 @@ librediffusion_set_lora_scale_vector(
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if (!scales)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
-  return try_catch_wrapper([&]() { pipeline->cpp_pipeline->set_lora_scale_vector(scales, n); });
+  return try_catch_wrapper(pipeline->device, [&]() { pipeline->cpp_pipeline->set_lora_scale_vector(scales, n); });
 }
 
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
@@ -1147,7 +1166,7 @@ librediffusion_reseed(librediffusion_pipeline_handle pipeline, int64_t seed)
   if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->reseed(seed);
   });
 }
@@ -1159,7 +1178,7 @@ librediffusion_set_guidance_scale(
   if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->set_guidance_scale(guidance);
   });
 }
@@ -1170,7 +1189,7 @@ librediffusion_set_delta(librediffusion_pipeline_handle pipeline, float delta)
   if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->set_delta(delta);
   });
 }
@@ -1193,7 +1212,7 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL librediffusion_img
   if (librediffusion_error_t e = check_inference_ready(pipeline); e != LIBREDIFFUSION_SUCCESS)
     return e;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->img2img(cpu_rgba_input, cpu_rgba_output, width, height);
   });
 }
@@ -1212,7 +1231,7 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL librediffusion_txt
   if (librediffusion_error_t e = check_inference_ready(pipeline); e != LIBREDIFFUSION_SUCCESS)
     return e;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->txt2img(cpu_rgba_output, width, height);
   });
 }
@@ -1234,7 +1253,7 @@ librediffusion_img2img_gpu_half(
   if (librediffusion_error_t e = check_inference_ready(pipeline); e != LIBREDIFFUSION_SUCCESS)
     return e;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->img2img_impl(
         to_half_ptr(image_in),
         to_half_ptr(image_out),
@@ -1255,7 +1274,7 @@ librediffusion_img2img_gpu_float(
   if (librediffusion_error_t e = check_inference_ready(pipeline); e != LIBREDIFFUSION_SUCCESS)
     return e;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->img2img_impl(
         image_in,
         to_half_ptr(image_out),
@@ -1275,7 +1294,7 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL librediffusion_txt
   if (librediffusion_error_t e = check_inference_ready(pipeline); e != LIBREDIFFUSION_SUCCESS)
     return e;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->txt2img_impl(
         to_half_ptr(image_out),
         to_cuda_stream(stream));
@@ -1295,7 +1314,7 @@ librediffusion_txt2img_sd_turbo_gpu(
   if (librediffusion_error_t e = check_inference_ready(pipeline); e != LIBREDIFFUSION_SUCCESS)
     return e;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->txt2img_sd_turbo_impl(
         to_half_ptr(image_out), to_cuda_stream(stream));
   });
@@ -1318,7 +1337,7 @@ librediffusion_encode_image_half(
       e != LIBREDIFFUSION_SUCCESS)
     return e;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->encode_image(
         to_half_ptr(image),
         to_half_ptr(latent_out),
@@ -1339,7 +1358,7 @@ librediffusion_encode_image_float(
       e != LIBREDIFFUSION_SUCCESS)
     return e;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->encode_image(
         image,
         to_half_ptr(latent_out),
@@ -1360,7 +1379,7 @@ librediffusion_decode_latent(
       e != LIBREDIFFUSION_SUCCESS)
     return e;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->decode_latent(
         to_half_ptr(latent),
         to_half_ptr(image_out),
@@ -1385,7 +1404,7 @@ librediffusion_predict_x0_batch(
   if (librediffusion_error_t e = check_inference_ready(pipeline); e != LIBREDIFFUSION_SUCCESS)
     return e;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->predict_x0_batch(
         to_half_ptr(x_t_latent_in),
         to_half_ptr(x_0_pred_out),
@@ -1409,7 +1428,7 @@ librediffusion_rgba_nhwc_to_nchw_float(
   if (width <= 0 || height <= 0)
     return LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->rgba_nhwc_to_nchw_gpu(
         rgba_nhwc_in, rgb_nchw_out, width, height, to_cuda_stream(stream));
   });
@@ -1428,7 +1447,7 @@ librediffusion_rgba_nhwc_to_nchw_half(
   if (width <= 0 || height <= 0)
     return LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->rgba_nhwc_to_nchw_gpu(
         rgba_nhwc_in, to_half_ptr(rgb_nchw_out), width, height, to_cuda_stream(stream));
   });
@@ -1446,7 +1465,7 @@ librediffusion_nchw_half_to_rgba_nhwc(
   if (width <= 0 || height <= 0)
     return LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->nchw_to_rgba_nhwc_gpu(
         to_half_ptr(rgb_nchw_in), rgba_nhwc_out, width, height, to_cuda_stream(stream));
   });
@@ -1464,7 +1483,7 @@ librediffusion_nchw_float_to_rgba_nhwc(
   if (width <= 0 || height <= 0)
     return LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->nchw_to_rgba_nhwc_gpu(
         rgb_nchw_in, rgba_nhwc_out, width, height, to_cuda_stream(stream));
   });
@@ -1481,7 +1500,7 @@ LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL librediffusion_rgb
   if (in_width <= 0 || in_height <= 0 || out_width <= 0 || out_height <= 0)
     return LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->rgba_resize(
         rgba_input, in_width, in_height,
         rgba_output, out_width, out_height);
@@ -1504,7 +1523,7 @@ librediffusion_enable_temporal_coherence(
   if (cache_interval < 1 || max_cached_frames < 1)
     return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->enableTemporalCoherence(
         use_feature_injection != 0,
         injection_strength,
@@ -1520,7 +1539,7 @@ librediffusion_disable_temporal_coherence(librediffusion_pipeline_handle pipelin
   if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->disableTemporalCoherence();
   });
 }
@@ -1531,7 +1550,7 @@ librediffusion_reset_temporal_state(librediffusion_pipeline_handle pipeline)
   if (!valid(pipeline))
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(pipeline->device, [&]() {
     pipeline->cpp_pipeline->resetTemporalState();
   });
 }
@@ -1552,16 +1571,24 @@ librediffusion_get_current_frame_id(librediffusion_pipeline_handle pipeline)
 struct librediffusion_clip_t
 {
   std::unique_ptr<librediffusion::CLIPWrapper> cpp_clip;
+  int device{0};
 };
 
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
-librediffusion_clip_create(const char* engine_path, librediffusion_clip_handle* clip)
+librediffusion_clip_create(
+    const char* engine_path, int device, librediffusion_clip_handle* clip)
 {
   if (!engine_path || !clip)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
+  *clip = nullptr;
 
-  return try_catch_wrapper([&]() {
+  const int dev = librediffusion::resolve_device(device);
+  if (dev < 0)
+    return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
+
+  return try_catch_wrapper(dev, [&]() {
     auto c = new librediffusion_clip_t{};
+    c->device = dev;
     c->cpp_clip = std::make_unique<librediffusion::CLIPWrapper>(engine_path);
     *clip = c;
   });
@@ -1583,7 +1610,7 @@ librediffusion_clip_compute_embeddings(
   if (!prompt || !embeddings)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(clip->device, [&]() {
     __half* result = clip->cpp_clip->computeEmbeddings(
         prompt, to_cuda_stream(stream), pad_token);
     *embeddings = reinterpret_cast<librediffusion_half_t*>(result);
@@ -1602,7 +1629,7 @@ librediffusion_clip_compute_embeddings_sdxl(
   if (!prompt || !embeddings || !pooled_embeds || !time_ids)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
 
-  return try_catch_wrapper([&]() {
+  return try_catch_wrapper(clip1->device, [&]() {
     auto result = librediffusion::computeClipEmbeddings_SDXL(
         *clip1->cpp_clip, *clip2->cpp_clip,
         prompt, batch_size, height, width,

--- a/src/librediffusion_c.flux2.cpp
+++ b/src/librediffusion_c.flux2.cpp
@@ -1,5 +1,6 @@
 /** FLUX.2-klein-4B C-API implementation (with streaming). */
 #include "librediffusion.flux2.hpp"
+#include "device_guard.hpp"
 #include "librediffusion_c.h"
 #include "cuda_error_state.hpp"
 #include "kernels.hpp"
@@ -35,22 +36,31 @@ struct CudaFreeGuard
 struct librediffusion_flux2
 {
   std::unique_ptr<Flux2Pipeline> pipe;
+  int device{0};
 };
 
 extern "C" {
 
 librediffusion_flux2_handle librediffusion_flux2_create(
     const char* transformer_engine, const char* qwen_engine, const char* vae_decoder_engine,
-    const char* vae_encoder_engine)
+    const char* vae_encoder_engine, int device)
 {
+  const int dev = resolve_device(device);
+  if(dev < 0)
+  {
+    fprintf(stderr, "flux2_create: device %d is not a valid CUDA device ordinal\n", device);
+    return nullptr;
+  }
   try
   {
+    DeviceGuard guard{dev};
     Flux2EnginePaths p;
     p.transformer = transformer_engine ? transformer_engine : "";
     p.qwen = qwen_engine ? qwen_engine : "";
     p.vae_decoder = vae_decoder_engine ? vae_decoder_engine : "";
     p.vae_encoder = vae_encoder_engine ? vae_encoder_engine : "";
     auto* h = new librediffusion_flux2;
+    h->device = dev;
     h->pipe = std::make_unique<Flux2Pipeline>(p);
     return h;
   }
@@ -64,6 +74,9 @@ librediffusion_flux2_handle librediffusion_flux2_create(
 
 void librediffusion_flux2_destroy(librediffusion_flux2_handle h)
 {
+  if(!h)
+    return;
+  DeviceGuard guard{h->device};
   delete h;
 }
 
@@ -72,6 +85,7 @@ librediffusion_error_t librediffusion_flux2_encode_text(
     int Lt)
 {
   if(!h || !h->pipe) return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
+  DeviceGuard guard{h->device};
   try
   {
     h->pipe->encode_text(
@@ -93,6 +107,7 @@ librediffusion_error_t librediffusion_flux2_txt2img(
     unsigned char* rgba_host, float* out_final_latent_host)
 {
   if(!h || !h->pipe) return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
+  DeviceGuard guard{h->device};
   try
   {
     const int Lp = Th * Tw;
@@ -146,6 +161,7 @@ librediffusion_error_t librediffusion_flux2_txt2img_ref(
     int num_steps, unsigned char* rgba_host, float* out_final_latent_host)
 {
   if(!h || !h->pipe) return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
+  DeviceGuard guard{h->device};
   try
   {
     const int Lp = Th * Tw;
@@ -226,6 +242,7 @@ struct librediffusion_flux2_stream
   std::vector<float> schedule;  // explicit FlowMatch sigma list (native scale). empty -> num_steps+strength.
   float* mask_dev = nullptr;    // inpaint mask, device [Lp] (1=regenerate, 0=keep)
   bool have_mask = false;       // mask_dev holds a valid inpaint mask
+  int device = 0;
 };
 
 extern "C" {
@@ -233,10 +250,17 @@ extern "C" {
 librediffusion_flux2_stream_handle librediffusion_flux2_stream_create(
     const char* transformer_engine, const char* qwen_engine, const char* vae_decoder_engine,
     const char* vae_encoder_engine, const char* tokenizer_json, int Th, int Tw,
-    unsigned long long seed)
+    unsigned long long seed, int device)
 {
+  const int dev = resolve_device(device);
+  if(dev < 0)
+  {
+    fprintf(stderr, "flux2_stream_create: device %d is not a valid CUDA device ordinal\n", device);
+    return nullptr;
+  }
   try
   {
+    DeviceGuard guard{dev};
     if(Th <= 0 || Tw <= 0)
       throw std::runtime_error(
           "klein token grid must be positive (got Th=" + std::to_string(Th) + ", Tw="
@@ -253,6 +277,7 @@ librediffusion_flux2_stream_handle librediffusion_flux2_stream_create(
     p.vae_encoder = vae_encoder_engine;
 
     auto* s = new librediffusion_flux2_stream;
+    s->device = dev;
     s->pipe = std::make_unique<Flux2Pipeline>(p);
     s->Th = Th; s->Tw = Tw; s->seed = seed;
     // LOW-priority non-blocking stream: background diffusion yields GPU scheduling to the render
@@ -296,6 +321,9 @@ librediffusion_flux2_stream_handle librediffusion_flux2_stream_create(
 
 void librediffusion_flux2_stream_destroy(librediffusion_flux2_stream_handle s)
 {
+  if(!s)
+    return;
+  DeviceGuard guard{s->device};
   if(!s) return;
   cudaFree(s->bn_mean); cudaFree(s->bn_std); cudaFree(s->img_ids); cudaFree(s->txt_ids);
   cudaFree(s->init_noise); cudaFree(s->ehs); cudaFree(s->ref_tokens); cudaFree(s->ref_ids);
@@ -369,6 +397,7 @@ librediffusion_flux2_stream_set_bn(
     librediffusion_flux2_stream_handle s, const float* bn_mean_host, const float* bn_std_host)
 {
   if(!s || !bn_mean_host || !bn_std_host) return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
+  DeviceGuard guard{s->device};
   cudaMemcpy(s->bn_mean, bn_mean_host, 128 * sizeof(float), cudaMemcpyHostToDevice);
   cudaMemcpy(s->bn_std, bn_std_host, 128 * sizeof(float), cudaMemcpyHostToDevice);
   return LIBREDIFFUSION_SUCCESS;
@@ -412,6 +441,7 @@ librediffusion_error_t librediffusion_flux2_stream_set_reference(
     librediffusion_flux2_stream_handle s, const unsigned char* input_rgba)
 {
   if(!s || !input_rgba) return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
+  DeviceGuard guard{s->device};
   try
   {
     const int Th = s->Th, Tw = s->Tw;
@@ -441,6 +471,7 @@ librediffusion_error_t librediffusion_flux2_stream_frame_cached(
     librediffusion_flux2_stream_handle s, unsigned char* output_rgba)
 {
   if(!s || !output_rgba) return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
+  DeviceGuard guard{s->device};
   if(!s->have_prompt || !s->have_reference) return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
   try
   {
@@ -473,6 +504,7 @@ librediffusion_error_t librediffusion_flux2_stream_frame(
     unsigned char* output_rgba)
 {
   if(!s || !input_rgba || !output_rgba) return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
+  DeviceGuard guard{s->device};
   if(!s->have_prompt) return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
   try
   {

--- a/src/librediffusion_c.flux2.cpp
+++ b/src/librediffusion_c.flux2.cpp
@@ -307,9 +307,15 @@ void librediffusion_flux2_stream_destroy(librediffusion_flux2_stream_handle s)
   delete s;
 }
 
-void librediffusion_flux2_stream_set_steps(librediffusion_flux2_stream_handle s, int num_steps)
+librediffusion_error_t
+librediffusion_flux2_stream_set_steps(librediffusion_flux2_stream_handle s, int num_steps)
 {
-  if(s && num_steps > 0) s->num_steps = num_steps;
+  if(!s)
+    return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
+  if(num_steps <= 0)
+    return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
+  s->num_steps = num_steps;
+  return LIBREDIFFUSION_SUCCESS;
 }
 
 void librediffusion_flux2_stream_set_strength(librediffusion_flux2_stream_handle s, float strength)

--- a/src/librediffusion_c.flux2.cpp
+++ b/src/librediffusion_c.flux2.cpp
@@ -237,6 +237,12 @@ librediffusion_flux2_stream_handle librediffusion_flux2_stream_create(
 {
   try
   {
+    // A grid with no tokens produced a valid handle reporting 0x0 dims, zero-byte allocations, and a
+    // context nothing else in the process could use afterwards.
+    if(Th <= 0 || Tw <= 0)
+      throw std::runtime_error(
+          "klein token grid must be positive (got Th=" + std::to_string(Th) + ", Tw="
+          + std::to_string(Tw) + ")");
     if(!vae_encoder_engine || !vae_encoder_engine[0])
       throw std::runtime_error("stream needs a vae_encoder engine (reference path)");
     if(!tokenizer_json || qwen_tokenizer_load(tokenizer_json) != 0)

--- a/src/librediffusion_c.flux2.cpp
+++ b/src/librediffusion_c.flux2.cpp
@@ -237,8 +237,6 @@ librediffusion_flux2_stream_handle librediffusion_flux2_stream_create(
 {
   try
   {
-    // A grid with no tokens produced a valid handle reporting 0x0 dims, zero-byte allocations, and a
-    // context nothing else in the process could use afterwards.
     if(Th <= 0 || Tw <= 0)
       throw std::runtime_error(
           "klein token grid must be positive (got Th=" + std::to_string(Th) + ", Tw="

--- a/src/librediffusion_c.flux2.cpp
+++ b/src/librediffusion_c.flux2.cpp
@@ -1,6 +1,7 @@
 /** FLUX.2-klein-4B C-API implementation (with streaming). */
 #include "librediffusion.flux2.hpp"
 #include "librediffusion_c.h"
+#include "cuda_error_state.hpp"
 #include "kernels.hpp"
 #include "qwen_tokenizer_c.h"
 
@@ -55,6 +56,7 @@ librediffusion_flux2_handle librediffusion_flux2_create(
   }
   catch(const std::exception& e)
   {
+    librediffusion::drain_cuda_error();
     fprintf(stderr, "flux2_create failed: %s\n", e.what());
     return nullptr;
   }
@@ -79,6 +81,7 @@ librediffusion_error_t librediffusion_flux2_encode_text(
   }
   catch(const std::exception& e)
   {
+    librediffusion::drain_cuda_error();
     fprintf(stderr, "flux2_encode_text failed: %s\n", e.what());
     return LIBREDIFFUSION_ERROR_INTERNAL;
   }
@@ -131,6 +134,7 @@ librediffusion_error_t librediffusion_flux2_txt2img(
   }
   catch(const std::exception& e)
   {
+    librediffusion::drain_cuda_error();
     fprintf(stderr, "flux2_txt2img failed: %s\n", e.what());
     return LIBREDIFFUSION_ERROR_INTERNAL;
   }
@@ -181,6 +185,7 @@ librediffusion_error_t librediffusion_flux2_txt2img_ref(
   }
   catch(const std::exception& e)
   {
+    librediffusion::drain_cuda_error();
     fprintf(stderr, "flux2_txt2img_ref failed: %s\n", e.what());
     return LIBREDIFFUSION_ERROR_INTERNAL;
   }
@@ -279,6 +284,7 @@ librediffusion_flux2_stream_handle librediffusion_flux2_stream_create(
   }
   catch(const std::exception& e)
   {
+    librediffusion::drain_cuda_error();
     fprintf(stderr, "flux2_stream_create failed: %s\n", e.what());
     return nullptr;
   }
@@ -383,6 +389,7 @@ int librediffusion_flux2_stream_set_prompt(librediffusion_flux2_stream_handle s,
   }
   catch(const std::exception& e)
   {
+    librediffusion::drain_cuda_error();
     fprintf(stderr, "stream_set_prompt failed: %s\n", e.what());
     return -1;
   }
@@ -413,6 +420,7 @@ librediffusion_error_t librediffusion_flux2_stream_set_reference(
   }
   catch(const std::exception& e)
   {
+    librediffusion::drain_cuda_error();
     fprintf(stderr, "stream_set_reference failed: %s\n", e.what());
     return LIBREDIFFUSION_ERROR_INTERNAL;
   }
@@ -444,6 +452,7 @@ librediffusion_error_t librediffusion_flux2_stream_frame_cached(
   }
   catch(const std::exception& e)
   {
+    librediffusion::drain_cuda_error();
     fprintf(stderr, "stream_frame_cached failed: %s\n", e.what());
     return LIBREDIFFUSION_ERROR_INTERNAL;
   }
@@ -481,6 +490,7 @@ librediffusion_error_t librediffusion_flux2_stream_frame(
   }
   catch(const std::exception& e)
   {
+    librediffusion::drain_cuda_error();
     fprintf(stderr, "stream_frame failed: %s\n", e.what());
     return LIBREDIFFUSION_ERROR_INTERNAL;
   }

--- a/src/librediffusion_c.h
+++ b/src/librediffusion_c.h
@@ -367,9 +367,12 @@ librediffusion_pipeline_reinit_buffers(
  *
  * @param pipeline      Pipeline handle
  * @param prompt_embeds Prompt embeddings [batch_size, seq_len, hidden_dim] as half
- * @param seq_len       Sequence length
- * @param hidden_dim    Hidden dimension
- * @return LIBREDIFFUSION_SUCCESS or error code
+ * @param seq_len       Sequence length; MUST equal the pipeline's configured text_seq_len
+ * @param hidden_dim    Hidden dimension; MUST equal the pipeline's configured text_hidden_dim
+ * @return LIBREDIFFUSION_SUCCESS, or LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS when the declared
+ *         shape disagrees with the pipeline's. The buffer is sized from these arguments while every
+ *         consumer reads text_seq_len*text_hidden_dim back out of it, so a mismatch would be an
+ *         out-of-bounds DEVICE read.
  */
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_prepare_embeds(
@@ -395,9 +398,9 @@ librediffusion_prepare_null_embeds(
  *
  * @param pipeline         Pipeline handle
  * @param negative_embeds  Negative embeddings [1, seq_len, hidden_dim] as half
- * @param seq_len          Sequence length
- * @param hidden_dim       Hidden dimension
- * @return LIBREDIFFUSION_SUCCESS or error code
+ * @param seq_len          Sequence length; MUST equal the pipeline's configured text_seq_len
+ * @param hidden_dim       Hidden dimension; MUST equal the pipeline's configured text_hidden_dim
+ * @return LIBREDIFFUSION_SUCCESS or LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS (see prepare_embeds)
  */
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_prepare_negative_embeds(
@@ -428,8 +431,14 @@ librediffusion_blend_embeds(
  * Prepare SDXL-specific conditioning.
  *
  * @param pipeline     Pipeline handle
- * @param text_embeds  Pooled text embeddings [batch_size, pooled_dim] as half
- * @param time_ids     Time IDs [batch_size, 6] as half
+ * The shapes are NOT passed: both buffers are read using the pipeline's own configured dimensions,
+ * so the caller must supply exactly [batch_size, pooled_embedding_dim] and [batch_size,
+ * time_ids_dim] as set via librediffusion_config_set_sdxl_config. Anything smaller is an
+ * out-of-bounds device read. Rejected outright on a pipeline that is not configured for SDXL
+ * conditioning.
+ *
+ * @param text_embeds  Pooled text embeddings [batch_size, pooled_embedding_dim] as half
+ * @param time_ids     Time IDs [batch_size, time_ids_dim] as half
  * @return LIBREDIFFUSION_SUCCESS or error code
  */
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL

--- a/src/librediffusion_c.h
+++ b/src/librediffusion_c.h
@@ -899,7 +899,8 @@ typedef struct librediffusion_clip_t* librediffusion_clip_handle;
  * @return LIBREDIFFUSION_SUCCESS or error code
  */
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
-librediffusion_clip_create(const char* engine_path, librediffusion_clip_handle* clip);
+librediffusion_clip_create(
+    const char* engine_path, int device, librediffusion_clip_handle* clip);
 
 /**
  * Destroy a CLIP encoder and free resources.
@@ -1094,7 +1095,7 @@ typedef struct librediffusion_flux2* librediffusion_flux2_handle;
 LIBREDIFFUSION_API librediffusion_flux2_handle LIBREDIFFUSION_CALL
 librediffusion_flux2_create(
     const char* transformer_engine, const char* qwen_engine, const char* vae_decoder_engine,
-    const char* vae_encoder_engine);
+    const char* vae_encoder_engine, int device);
 
 LIBREDIFFUSION_API void LIBREDIFFUSION_CALL
 librediffusion_flux2_destroy(librediffusion_flux2_handle h);
@@ -1157,7 +1158,7 @@ LIBREDIFFUSION_API librediffusion_flux2_stream_handle LIBREDIFFUSION_CALL
 librediffusion_flux2_stream_create(
     const char* transformer_engine, const char* qwen_engine, const char* vae_decoder_engine,
     const char* vae_encoder_engine, const char* tokenizer_json, int Th, int Tw,
-    unsigned long long seed);
+    unsigned long long seed, int device);
 
 LIBREDIFFUSION_API void LIBREDIFFUSION_CALL
 librediffusion_flux2_stream_destroy(librediffusion_flux2_stream_handle s);
@@ -1242,7 +1243,7 @@ typedef struct librediffusion_rife* librediffusion_rife_handle;
 
 /* Create a RIFE interpolator from the IFNet fp16 engine path. Returns NULL on failure. */
 LIBREDIFFUSION_API librediffusion_rife_handle LIBREDIFFUSION_CALL
-librediffusion_rife_create(const char* engine_path);
+librediffusion_rife_create(const char* engine_path, int device);
 
 LIBREDIFFUSION_API void LIBREDIFFUSION_CALL
 librediffusion_rife_destroy(librediffusion_rife_handle h);
@@ -1314,7 +1315,8 @@ typedef struct librediffusion_img2img_turbo* librediffusion_img2img_turbo_handle
 
 LIBREDIFFUSION_API librediffusion_img2img_turbo_handle LIBREDIFFUSION_CALL
 librediffusion_img2img_turbo_create(
-    const char* unet_engine, const char* vae_encoder_engine, const char* vae_decoder_engine);
+    const char* unet_engine, const char* vae_encoder_engine, const char* vae_decoder_engine,
+    int device);
 
 LIBREDIFFUSION_API void LIBREDIFFUSION_CALL
 librediffusion_img2img_turbo_destroy(librediffusion_img2img_turbo_handle h);

--- a/src/librediffusion_c.h
+++ b/src/librediffusion_c.h
@@ -78,6 +78,10 @@ typedef enum librediffusion_error_t
   LIBREDIFFUSION_ERROR_NOT_INITIALIZED = -6,
   LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS = -7,
   LIBREDIFFUSION_ERROR_FILE_NOT_FOUND = -8,
+  /* The CUDA context is dead (illegal address, launch failure, ECC, ...). Unlike
+   * LIBREDIFFUSION_ERROR_CUDA_ERROR this cannot be cleared: every later call in this process will
+   * return it too, and only a restart recovers. */
+  LIBREDIFFUSION_ERROR_CUDA_CONTEXT_LOST = -9,
   LIBREDIFFUSION_ERROR_INTERNAL = -99
 } librediffusion_error_t;
 

--- a/src/librediffusion_c.h
+++ b/src/librediffusion_c.h
@@ -1335,6 +1335,13 @@ librediffusion_img2img_turbo_frame_bytes(librediffusion_img2img_turbo_handle h);
 LIBREDIFFUSION_API int LIBREDIFFUSION_CALL
 librediffusion_img2img_turbo_ehs_elements(librediffusion_img2img_turbo_handle h);
 
+/* The same geometry as width and height, for callers that must rescale their input to it or
+ * allocate an output texture (frame_bytes alone cannot tell a 512x512 engine from a 256x1024 one).
+ * Writes nothing and returns LIBREDIFFUSION_ERROR_NOT_INITIALIZED on a null handle. */
+LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
+librediffusion_img2img_turbo_frame_size(
+    librediffusion_img2img_turbo_handle h, int* out_width, int* out_height);
+
 /* HOST-bytes convenience (mirrors flux2_stream_frame): RGBA8 [H,W,4] in + host ehs[1,77,1024]
  * -> RGBA8 [H,W,4] out. Does all host<->device copies + RGBA<->CHW conversion internally, so callers
  * with no CUDA (e.g. the score node) only pass plain byte/float buffers. The geometry is the

--- a/src/librediffusion_c.h
+++ b/src/librediffusion_c.h
@@ -164,11 +164,9 @@ librediffusion_config_set_device(librediffusion_config_handle config, int device
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_config_set_model_type(
     librediffusion_config_handle config, librediffusion_model_type_t type);
-/* Image and latent geometry. Validated: width/height must be positive, <= 16384, and multiples of
- * 8; latent_width/latent_height must be exactly width/8 and height/8 (the VAE's downsampling
- * factor). Anything else is LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS — every kernel indexes one grid
- * and the engine the other, and an oversized pair overflows the int the buffer sizes are computed
- * in before reaching an unchecked cudaMalloc. */
+/* Image and latent geometry. width/height must be positive, <= 16384 and multiples of 8;
+ * latent_width/latent_height must be exactly width/8 and height/8 (the VAE's downsampling factor).
+ * Anything else returns LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS. */
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_config_set_dimensions(
     librediffusion_config_handle config, int width, int height, int latent_width,
@@ -379,9 +377,7 @@ librediffusion_pipeline_reinit_buffers(
  * @param seq_len       Sequence length; MUST equal the pipeline's configured text_seq_len
  * @param hidden_dim    Hidden dimension; MUST equal the pipeline's configured text_hidden_dim
  * @return LIBREDIFFUSION_SUCCESS, or LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS when the declared
- *         shape disagrees with the pipeline's. The buffer is sized from these arguments while every
- *         consumer reads text_seq_len*text_hidden_dim back out of it, so a mismatch would be an
- *         out-of-bounds DEVICE read.
+ *         shape disagrees with the pipeline's.
  */
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_prepare_embeds(
@@ -1252,14 +1248,11 @@ librediffusion_rife_set_enabled(librediffusion_rife_handle h, int enabled);
 LIBREDIFFUSION_API int LIBREDIFFUSION_CALL
 librediffusion_rife_is_enabled(librediffusion_rife_handle h);
 
-/* Largest interpolation exponent the library accepts: 2^4 = 16 frames per real frame, already far
- * beyond what any display pipeline consumes. set_interpolation_exp CLAMPS to [0, this]. */
+/* Largest interpolation exponent the library accepts (2^4 = 16 frames per real frame). */
 #define LIBREDIFFUSION_RIFE_MAX_EXP 4
 
 /* interpolation_exp: 0 = off (1 frame out), 1 = 2x, 2 = 4x, 3 = 8x displayed frames.
- * Clamped to [0, LIBREDIFFUSION_RIFE_MAX_EXP]: it used to be clamped only from below and stored
- * verbatim, so a readback of 2147483647 was possible and the internal `total_out *= 2` loop was
- * signed overflow (UB) from exp = 31 up. */
+ * Clamped to [0, LIBREDIFFUSION_RIFE_MAX_EXP]. */
 LIBREDIFFUSION_API void LIBREDIFFUSION_CALL
 librediffusion_rife_set_interpolation_exp(librediffusion_rife_handle h, int exp);
 
@@ -1278,9 +1271,8 @@ librediffusion_rife_required_out_bytes(librediffusion_rife_handle h, int H, int 
  *
  * PREFERRED FORM. out_capacity_bytes is what the caller actually allocated; the number of frames
  * written is derived from state set in a DIFFERENT call (set_interpolation_exp), so the two drift
- * apart trivially — any host that raises the interpolation factor without re-sizing its buffer used
- * to overflow it silently. A capacity smaller than
- * librediffusion_rife_required_out_bytes() is LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS. */
+ * apart trivially. A capacity smaller than librediffusion_rife_required_out_bytes() returns
+ * LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS. */
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_rife_interpolate_sized(
     librediffusion_rife_handle h, const unsigned char* prev_rgba, const unsigned char* cur_rgba,
@@ -1293,9 +1285,8 @@ librediffusion_rife_interpolate_gpu_sized(
     const unsigned char* cur_rgba_dev, int H, int W, unsigned char* out_frames_dev,
     size_t out_capacity_bytes, int* out_count);
 
-/* DEPRECATED (kept for ABI compatibility): out_frames carries no length, so the library cannot
- * check that it is big enough for the (2^exp)*H*W*4 bytes it is about to write. The caller must
- * size it from librediffusion_rife_required_out_bytes() itself. Prefer the _sized forms. */
+/* DEPRECATED: out_frames carries no length, so the (2^exp)*H*W*4 bytes it is about to write cannot
+ * be checked. Size it from librediffusion_rife_required_out_bytes(). Prefer the _sized forms. */
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_rife_interpolate(
     librediffusion_rife_handle h, const unsigned char* prev_rgba, const unsigned char* cur_rgba,
@@ -1329,8 +1320,7 @@ librediffusion_img2img_turbo_forward(
 
 /* Exact buffer requirements of the _frame entry points below, for the loaded engines.
  * frame_bytes = H*W*4 (each of in_rgba and out_rgba); ehs_elements = 77*1024 floats.
- * Both return 0 on a null handle. ADDED alongside the _sized entry points; a caller that cannot
- * resolve them is running an older .so and must assume the historical static 512x512 / 77x1024. */
+ * Both return 0 on a null handle, and are absent from older .so builds (assume 512x512 / 77x1024). */
 LIBREDIFFUSION_API int LIBREDIFFUSION_CALL
 librediffusion_img2img_turbo_frame_bytes(librediffusion_img2img_turbo_handle h);
 
@@ -1344,7 +1334,7 @@ librediffusion_img2img_turbo_ehs_elements(librediffusion_img2img_turbo_handle h)
  * PREFERRED FORM. The caller declares the length of every buffer the call touches, so a mismatch is
  * LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS instead of a silent overflow: the implementation copies
  * H*W*4 bytes out of in_rgba, H*W*4 bytes into out_rgba and 77*1024 floats out of ehs, all sized
- * from the ENGINE rather than from anything the caller said.
+ * from the ENGINE, not from anything the caller said.
  *   in_bytes / out_bytes  = librediffusion_img2img_turbo_frame_bytes(h)
  *   ehs_elements          = librediffusion_img2img_turbo_ehs_elements(h) */
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
@@ -1360,10 +1350,8 @@ librediffusion_img2img_turbo_frame_dev_sized(
     librediffusion_img2img_turbo_handle h, const unsigned char* in_rgba, size_t in_bytes,
     const librediffusion_half_t* ehs_dev, unsigned char* out_rgba, size_t out_bytes);
 
-/* DEPRECATED (kept for ABI compatibility with existing callers). Identical behaviour to
- * _frame_sized called with the model's own sizes — which means it CANNOT detect a caller whose
- * buffers are smaller than that, because it is never told how big they are. Migrate to
- * _frame_sized / _frame_dev_sized. */
+/* DEPRECATED. Identical to _frame_sized called with the model's own sizes — which means it CANNOT
+ * detect a caller whose buffers are smaller. Migrate to _frame_sized / _frame_dev_sized. */
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_img2img_turbo_frame(
     librediffusion_img2img_turbo_handle h, const unsigned char* in_rgba, const float* ehs,

--- a/src/librediffusion_c.h
+++ b/src/librediffusion_c.h
@@ -1338,12 +1338,13 @@ librediffusion_img2img_turbo_ehs_elements(librediffusion_img2img_turbo_handle h)
  * -> RGBA8 [H,W,4] out. Does all host<->device copies + RGBA<->CHW conversion internally, so callers
  * with no CUDA (e.g. the score node) only pass plain byte/float buffers. Model is static 512x512.
  *
- * PREFERRED FORM. The caller declares the length of every buffer the call touches, so a mismatch is
- * LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS instead of a silent overflow: the implementation copies
- * H*W*4 bytes out of in_rgba, H*W*4 bytes into out_rgba and 77*1024 floats out of ehs, all sized
- * from the ENGINE, not from anything the caller said.
- *   in_bytes / out_bytes  = librediffusion_img2img_turbo_frame_bytes(h)
- *   ehs_elements          = librediffusion_img2img_turbo_ehs_elements(h) */
+ * PREFERRED FORM. The caller declares the CAPACITY of every buffer the call touches, so a short
+ * buffer is LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS instead of a silent overflow: the
+ * implementation copies H*W*4 bytes out of in_rgba, H*W*4 bytes into out_rgba and 77*1024 floats
+ * out of ehs, all sized from the ENGINE, not from anything the caller said. Over-allocating is
+ * accepted; the extra bytes are untouched.
+ *   in_bytes / out_bytes  >= librediffusion_img2img_turbo_frame_bytes(h)
+ *   ehs_elements          >= librediffusion_img2img_turbo_ehs_elements(h) */
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_img2img_turbo_frame_sized(
     librediffusion_img2img_turbo_handle h, const unsigned char* in_rgba, size_t in_bytes,

--- a/src/librediffusion_c.h
+++ b/src/librediffusion_c.h
@@ -1325,8 +1325,9 @@ librediffusion_img2img_turbo_forward(
     librediffusion_img2img_turbo_handle h, const void* image_dev, const void* ehs_dev, void* out_dev,
     librediffusion_stream_t stream);
 
-/* Exact buffer requirements of the _frame entry points below, for the loaded engines.
- * frame_bytes = H*W*4 (each of in_rgba and out_rgba); ehs_elements = 77*1024 floats.
+/* Exact buffer requirements of the _frame entry points below, read out of the LOADED engines:
+ * frame_bytes = H*W*4 (each of in_rgba and out_rgba) from the VAE encoder's "image" input;
+ * ehs_elements = seq*dim from the UNet's "ehs" input (77*1024 on the SD2.1-derived exports).
  * Both return 0 on a null handle, and are absent from older .so builds (assume 512x512 / 77x1024). */
 LIBREDIFFUSION_API int LIBREDIFFUSION_CALL
 librediffusion_img2img_turbo_frame_bytes(librediffusion_img2img_turbo_handle h);
@@ -1336,7 +1337,8 @@ librediffusion_img2img_turbo_ehs_elements(librediffusion_img2img_turbo_handle h)
 
 /* HOST-bytes convenience (mirrors flux2_stream_frame): RGBA8 [H,W,4] in + host ehs[1,77,1024]
  * -> RGBA8 [H,W,4] out. Does all host<->device copies + RGBA<->CHW conversion internally, so callers
- * with no CUDA (e.g. the score node) only pass plain byte/float buffers. Model is static 512x512.
+ * with no CUDA (e.g. the score node) only pass plain byte/float buffers. The geometry is the
+ * engines' own -- ask librediffusion_img2img_turbo_frame_bytes(), do not assume 512x512.
  *
  * PREFERRED FORM. The caller declares the CAPACITY of every buffer the call touches, so a short
  * buffer is LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS instead of a silent overflow: the

--- a/src/librediffusion_c.h
+++ b/src/librediffusion_c.h
@@ -1243,23 +1243,55 @@ librediffusion_rife_set_enabled(librediffusion_rife_handle h, int enabled);
 LIBREDIFFUSION_API int LIBREDIFFUSION_CALL
 librediffusion_rife_is_enabled(librediffusion_rife_handle h);
 
-/* interpolation_exp: 0 = off (1 frame out), 1 = 2x, 2 = 4x, 3 = 8x displayed frames. */
+/* Largest interpolation exponent the library accepts: 2^4 = 16 frames per real frame, already far
+ * beyond what any display pipeline consumes. set_interpolation_exp CLAMPS to [0, this]. */
+#define LIBREDIFFUSION_RIFE_MAX_EXP 4
+
+/* interpolation_exp: 0 = off (1 frame out), 1 = 2x, 2 = 4x, 3 = 8x displayed frames.
+ * Clamped to [0, LIBREDIFFUSION_RIFE_MAX_EXP]: it used to be clamped only from below and stored
+ * verbatim, so a readback of 2147483647 was possible and the internal `total_out *= 2` loop was
+ * signed overflow (UB) from exp = 31 up. */
 LIBREDIFFUSION_API void LIBREDIFFUSION_CALL
 librediffusion_rife_set_interpolation_exp(librediffusion_rife_handle h, int exp);
 
 LIBREDIFFUSION_API int LIBREDIFFUSION_CALL
 librediffusion_rife_get_interpolation_exp(librediffusion_rife_handle h);
 
+/* Exact byte capacity out_frames must have for the CURRENT exp / enabled state at this geometry:
+ * (2^exp)*H*W*4, or H*W*4 when disabled. 0 on a null handle or non-positive geometry. */
+LIBREDIFFUSION_API int LIBREDIFFUSION_CALL
+librediffusion_rife_required_out_bytes(librediffusion_rife_handle h, int H, int W);
+
 /* Interpolate between two consecutive real RGBA frames (HOST uint8 [H*W*4] each).
- * Writes up to (2^exp) frames into out_frames (caller-sized (2^exp)*H*W*4); display order,
- * last frame == cur. *out_count receives the number of frames written.
- * When disabled (or exp==0), writes 1 frame (cur) and *out_count = 1. */
+ * Writes up to (2^exp) frames into out_frames; display order, last frame == cur. *out_count
+ * receives the number of frames written. When disabled (or exp==0), writes 1 frame (cur) and
+ * *out_count = 1.
+ *
+ * PREFERRED FORM. out_capacity_bytes is what the caller actually allocated; the number of frames
+ * written is derived from state set in a DIFFERENT call (set_interpolation_exp), so the two drift
+ * apart trivially — any host that raises the interpolation factor without re-sizing its buffer used
+ * to overflow it silently. A capacity smaller than
+ * librediffusion_rife_required_out_bytes() is LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS. */
+LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
+librediffusion_rife_interpolate_sized(
+    librediffusion_rife_handle h, const unsigned char* prev_rgba, const unsigned char* cur_rgba,
+    int H, int W, unsigned char* out_frames, size_t out_capacity_bytes, int* out_count);
+
+/* Device-pointer variant of _sized: prev/cur RGBA uint8 on DEVICE; out_frames RGBA uint8 on DEVICE. */
+LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
+librediffusion_rife_interpolate_gpu_sized(
+    librediffusion_rife_handle h, const unsigned char* prev_rgba_dev,
+    const unsigned char* cur_rgba_dev, int H, int W, unsigned char* out_frames_dev,
+    size_t out_capacity_bytes, int* out_count);
+
+/* DEPRECATED (kept for ABI compatibility): out_frames carries no length, so the library cannot
+ * check that it is big enough for the (2^exp)*H*W*4 bytes it is about to write. The caller must
+ * size it from librediffusion_rife_required_out_bytes() itself. Prefer the _sized forms. */
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_rife_interpolate(
     librediffusion_rife_handle h, const unsigned char* prev_rgba, const unsigned char* cur_rgba,
     int H, int W, unsigned char* out_frames, int* out_count);
 
-/* Device-pointer variant: prev/cur RGBA uint8 on DEVICE; out_frames RGBA uint8 on DEVICE. */
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_rife_interpolate_gpu(
     librediffusion_rife_handle h, const unsigned char* prev_rgba_dev,

--- a/src/librediffusion_c.h
+++ b/src/librediffusion_c.h
@@ -1286,16 +1286,48 @@ librediffusion_img2img_turbo_forward(
     librediffusion_img2img_turbo_handle h, const void* image_dev, const void* ehs_dev, void* out_dev,
     librediffusion_stream_t stream);
 
+/* Exact buffer requirements of the _frame entry points below, for the loaded engines.
+ * frame_bytes = H*W*4 (each of in_rgba and out_rgba); ehs_elements = 77*1024 floats.
+ * Both return 0 on a null handle. ADDED alongside the _sized entry points; a caller that cannot
+ * resolve them is running an older .so and must assume the historical static 512x512 / 77x1024. */
+LIBREDIFFUSION_API int LIBREDIFFUSION_CALL
+librediffusion_img2img_turbo_frame_bytes(librediffusion_img2img_turbo_handle h);
+
+LIBREDIFFUSION_API int LIBREDIFFUSION_CALL
+librediffusion_img2img_turbo_ehs_elements(librediffusion_img2img_turbo_handle h);
+
 /* HOST-bytes convenience (mirrors flux2_stream_frame): RGBA8 [H,W,4] in + host ehs[1,77,1024]
  * -> RGBA8 [H,W,4] out. Does all host<->device copies + RGBA<->CHW conversion internally, so callers
- * with no CUDA (e.g. the score node) only pass plain byte/float buffers. Model is static 512x512. */
+ * with no CUDA (e.g. the score node) only pass plain byte/float buffers. Model is static 512x512.
+ *
+ * PREFERRED FORM. The caller declares the length of every buffer the call touches, so a mismatch is
+ * LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS instead of a silent overflow: the implementation copies
+ * H*W*4 bytes out of in_rgba, H*W*4 bytes into out_rgba and 77*1024 floats out of ehs, all sized
+ * from the ENGINE rather than from anything the caller said.
+ *   in_bytes / out_bytes  = librediffusion_img2img_turbo_frame_bytes(h)
+ *   ehs_elements          = librediffusion_img2img_turbo_ehs_elements(h) */
+LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
+librediffusion_img2img_turbo_frame_sized(
+    librediffusion_img2img_turbo_handle h, const unsigned char* in_rgba, size_t in_bytes,
+    const float* ehs, size_t ehs_elements, unsigned char* out_rgba, size_t out_bytes);
+
+/* Like _frame_sized but ehs is a DEVICE fp16 [1,77,1024] (e.g. straight from
+ * clip_compute_embeddings), whose length is the engine's rather than the caller's. Image is still
+ * HOST RGBA8 [H,W,4] in/out and IS declared. */
+LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
+librediffusion_img2img_turbo_frame_dev_sized(
+    librediffusion_img2img_turbo_handle h, const unsigned char* in_rgba, size_t in_bytes,
+    const librediffusion_half_t* ehs_dev, unsigned char* out_rgba, size_t out_bytes);
+
+/* DEPRECATED (kept for ABI compatibility with existing callers). Identical behaviour to
+ * _frame_sized called with the model's own sizes — which means it CANNOT detect a caller whose
+ * buffers are smaller than that, because it is never told how big they are. Migrate to
+ * _frame_sized / _frame_dev_sized. */
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_img2img_turbo_frame(
     librediffusion_img2img_turbo_handle h, const unsigned char* in_rgba, const float* ehs,
     unsigned char* out_rgba);
 
-/* Like _frame but ehs is a DEVICE fp16 [1,77,1024] (e.g. straight from clip_compute_embeddings);
- * converted to fp32 internally. Image is still HOST RGBA8 [H,W,4] in/out. */
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_img2img_turbo_frame_dev(
     librediffusion_img2img_turbo_handle h, const unsigned char* in_rgba,

--- a/src/librediffusion_c.h
+++ b/src/librediffusion_c.h
@@ -1161,7 +1161,7 @@ LIBREDIFFUSION_API void LIBREDIFFUSION_CALL
 librediffusion_flux2_stream_destroy(librediffusion_flux2_stream_handle s);
 
 /* Number of inference steps (default 2). */
-LIBREDIFFUSION_API void LIBREDIFFUSION_CALL
+LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_flux2_stream_set_steps(librediffusion_flux2_stream_handle s, int num_steps);
 
 /* img2img strength [0..1] (default 1.0). 1.0 = edit from pure noise (reference as conditioning only);

--- a/src/librediffusion_c.h
+++ b/src/librediffusion_c.h
@@ -160,6 +160,11 @@ librediffusion_config_set_device(librediffusion_config_handle config, int device
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_config_set_model_type(
     librediffusion_config_handle config, librediffusion_model_type_t type);
+/* Image and latent geometry. Validated: width/height must be positive, <= 16384, and multiples of
+ * 8; latent_width/latent_height must be exactly width/8 and height/8 (the VAE's downsampling
+ * factor). Anything else is LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS — every kernel indexes one grid
+ * and the engine the other, and an oversized pair overflows the int the buffer sizes are computed
+ * in before reaching an unchecked cudaMalloc. */
 LIBREDIFFUSION_API librediffusion_error_t LIBREDIFFUSION_CALL
 librediffusion_config_set_dimensions(
     librediffusion_config_handle config, int width, int height, int latent_width,

--- a/src/librediffusion_c.h
+++ b/src/librediffusion_c.h
@@ -817,11 +817,17 @@ librediffusion_nchw_float_to_rgba_nhwc(
 /**
  * Resize RGBA image on GPU.
  *
+ * BOTH BUFFERS MUST BE DEVICE POINTERS. This runs NPP directly on the pointers it is given, with
+ * no host staging and no cudaPointerGetAttributes probe. Passing a host buffer is an illegal
+ * device access, which is a STICKY CUDA error: it does not fail this call, it destroys the CUDA
+ * context and every later entry point in the process returns
+ * LIBREDIFFUSION_ERROR_CUDA_CONTEXT_LOST. cudaMemcpy host pixels to a device buffer first.
+ *
  * @param pipeline      Pipeline handle
- * @param rgba_input    Input [in_height, in_width, 4] as uint8
+ * @param rgba_input    DEVICE pointer, input [in_height, in_width, 4] as uint8
  * @param in_width      Input width
  * @param in_height     Input height
- * @param rgba_output   Output [out_height, out_width, 4] as uint8
+ * @param rgba_output   DEVICE pointer, output [out_height, out_width, 4] as uint8
  * @param out_width     Output width
  * @param out_height    Output height
  * @return LIBREDIFFUSION_SUCCESS or error code

--- a/src/librediffusion_c.h
+++ b/src/librediffusion_c.h
@@ -1266,8 +1266,9 @@ LIBREDIFFUSION_API int LIBREDIFFUSION_CALL
 librediffusion_rife_get_interpolation_exp(librediffusion_rife_handle h);
 
 /* Exact byte capacity out_frames must have for the CURRENT exp / enabled state at this geometry:
- * (2^exp)*H*W*4, or H*W*4 when disabled. 0 on a null handle or non-positive geometry. */
-LIBREDIFFUSION_API int LIBREDIFFUSION_CALL
+ * (2^exp)*H*W*4, or H*W*4 when disabled. 0 on a null handle or non-positive geometry. size_t,
+ * because the product exceeds INT_MAX well inside the supported range (4096x4096 at exp 4). */
+LIBREDIFFUSION_API size_t LIBREDIFFUSION_CALL
 librediffusion_rife_required_out_bytes(librediffusion_rife_handle h, int H, int W);
 
 /* Interpolate between two consecutive real RGBA frames (HOST uint8 [H*W*4] each).

--- a/src/librediffusion_c.img2img_turbo.cpp
+++ b/src/librediffusion_c.img2img_turbo.cpp
@@ -164,6 +164,18 @@ int librediffusion_img2img_turbo_ehs_elements(librediffusion_img2img_turbo_handl
   return h->pipe->ehsElements();
 }
 
+librediffusion_error_t librediffusion_img2img_turbo_frame_size(
+    librediffusion_img2img_turbo_handle h, int* out_width, int* out_height)
+{
+  if(!h || !h->pipe)
+    return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
+  if(!out_width || !out_height)
+    return LIBREDIFFUSION_ERROR_NULL_POINTER;
+  *out_width = h->pipe->frameWidth();
+  *out_height = h->pipe->frameHeight();
+  return LIBREDIFFUSION_SUCCESS;
+}
+
 /* DEPRECATED: these declare no sizes, so the caller's buffers cannot be checked. Prefer _sized. */
 librediffusion_error_t librediffusion_img2img_turbo_frame(
     librediffusion_img2img_turbo_handle h, const unsigned char* in_rgba, const float* ehs,

--- a/src/librediffusion_c.img2img_turbo.cpp
+++ b/src/librediffusion_c.img2img_turbo.cpp
@@ -78,20 +78,23 @@ librediffusion_error_t check_frame_sizes(
 {
   const size_t need = (size_t)h->pipe->frameHeight() * h->pipe->frameWidth() * 4;
   const size_t need_ehs = (size_t)librediffusion::Img2ImgTurboPipeline::kEhsElements;
-  if(in_bytes != need || out_bytes != need)
+  // Capacity, not equality (same contract as rife's check_out_capacity): the entry points read
+  // `need` bytes and write `need` bytes, so a caller who over-allocated is safe and must not be
+  // refused. Only a SHORT buffer is a bug.
+  if(in_bytes < need || out_bytes < need)
   {
     fprintf(
         stderr,
-        "img2img_turbo: buffer size mismatch — model is %dx%d (%zu bytes per frame), caller "
+        "img2img_turbo: buffer too small — model is %dx%d (%zu bytes per frame), caller "
         "declared in=%zu out=%zu\n",
         h->pipe->frameWidth(), h->pipe->frameHeight(), need, in_bytes, out_bytes);
     return LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS;
   }
-  if(ehs_elements != need_ehs)
+  if(ehs_elements < need_ehs)
   {
     fprintf(
         stderr,
-        "img2img_turbo: embedding size mismatch — the model reads %zu floats [1,77,1024], caller "
+        "img2img_turbo: embedding too small — the model reads %zu floats [1,77,1024], caller "
         "declared %zu\n",
         need_ehs, ehs_elements);
     return LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS;

--- a/src/librediffusion_c.img2img_turbo.cpp
+++ b/src/librediffusion_c.img2img_turbo.cpp
@@ -69,14 +69,50 @@ librediffusion_error_t librediffusion_img2img_turbo_forward(
   }
 }
 
-librediffusion_error_t librediffusion_img2img_turbo_frame(
-    librediffusion_img2img_turbo_handle h, const unsigned char* in_rgba, const float* ehs,
-    unsigned char* out_rgba)
+namespace
+{
+// L-03: the unsized _frame entry points copy H_*W_*4 bytes out of `in_rgba`, H_*W_*4 bytes INTO
+// `out_rgba` and 77*1024 floats out of `ehs` — none of which the caller ever declared. The _sized
+// variants below carry those declarations so the library can refuse a mismatch instead of walking
+// off the end of three host buffers.
+librediffusion_error_t check_frame_sizes(
+    librediffusion_img2img_turbo_handle h, size_t in_bytes, size_t ehs_elements, size_t out_bytes)
+{
+  const size_t need = (size_t)h->pipe->frameHeight() * h->pipe->frameWidth() * 4;
+  const size_t need_ehs = (size_t)librediffusion::Img2ImgTurboPipeline::kEhsElements;
+  if(in_bytes != need || out_bytes != need)
+  {
+    fprintf(
+        stderr,
+        "img2img_turbo: buffer size mismatch — model is %dx%d (%zu bytes per frame), caller "
+        "declared in=%zu out=%zu\n",
+        h->pipe->frameWidth(), h->pipe->frameHeight(), need, in_bytes, out_bytes);
+    return LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS;
+  }
+  if(ehs_elements != need_ehs)
+  {
+    fprintf(
+        stderr,
+        "img2img_turbo: embedding size mismatch — the model reads %zu floats [1,77,1024], caller "
+        "declared %zu\n",
+        need_ehs, ehs_elements);
+    return LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS;
+  }
+  return LIBREDIFFUSION_SUCCESS;
+}
+} // namespace
+
+librediffusion_error_t librediffusion_img2img_turbo_frame_sized(
+    librediffusion_img2img_turbo_handle h, const unsigned char* in_rgba, size_t in_bytes,
+    const float* ehs, size_t ehs_elements, unsigned char* out_rgba, size_t out_bytes)
 {
   if(!h || !h->pipe)
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if(!in_rgba || !ehs || !out_rgba)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
+  if(librediffusion_error_t e = check_frame_sizes(h, in_bytes, ehs_elements, out_bytes);
+     e != LIBREDIFFUSION_SUCCESS)
+    return e;
   try
   {
     h->pipe->forward_rgba(in_rgba, ehs, out_rgba, 0);  // host bytes in/out; syncs the stream
@@ -89,14 +125,19 @@ librediffusion_error_t librediffusion_img2img_turbo_frame(
   }
 }
 
-librediffusion_error_t librediffusion_img2img_turbo_frame_dev(
-    librediffusion_img2img_turbo_handle h, const unsigned char* in_rgba,
-    const librediffusion_half_t* ehs_dev, unsigned char* out_rgba)
+librediffusion_error_t librediffusion_img2img_turbo_frame_dev_sized(
+    librediffusion_img2img_turbo_handle h, const unsigned char* in_rgba, size_t in_bytes,
+    const librediffusion_half_t* ehs_dev, unsigned char* out_rgba, size_t out_bytes)
 {
   if(!h || !h->pipe)
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   if(!in_rgba || !ehs_dev || !out_rgba)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
+  // ehs is a DEVICE buffer here; its length is the engine's and is not the caller's to get wrong.
+  if(librediffusion_error_t e = check_frame_sizes(
+         h, in_bytes, (size_t)librediffusion::Img2ImgTurboPipeline::kEhsElements, out_bytes);
+     e != LIBREDIFFUSION_SUCCESS)
+    return e;
   try
   {
     h->pipe->forward_rgba_dev(in_rgba, ehs_dev, out_rgba, 0);  // device fp16 ehs; syncs the stream
@@ -107,6 +148,43 @@ librediffusion_error_t librediffusion_img2img_turbo_frame_dev(
     fprintf(stderr, "img2img_turbo_frame_dev failed: %s\n", e.what());
     return LIBREDIFFUSION_ERROR_INTERNAL;
   }
+}
+
+int librediffusion_img2img_turbo_frame_bytes(librediffusion_img2img_turbo_handle h)
+{
+  if(!h || !h->pipe)
+    return 0;
+  return h->pipe->frameHeight() * h->pipe->frameWidth() * 4;
+}
+
+int librediffusion_img2img_turbo_ehs_elements(librediffusion_img2img_turbo_handle h)
+{
+  if(!h || !h->pipe)
+    return 0;
+  return librediffusion::Img2ImgTurboPipeline::kEhsElements;
+}
+
+/* DEPRECATED, kept for ABI compatibility: these declare no sizes, so the library CANNOT check that
+ * the caller's buffers are big enough for what it copies. Prefer the _sized variants above. */
+librediffusion_error_t librediffusion_img2img_turbo_frame(
+    librediffusion_img2img_turbo_handle h, const unsigned char* in_rgba, const float* ehs,
+    unsigned char* out_rgba)
+{
+  if(!h || !h->pipe)
+    return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
+  const size_t n = (size_t)h->pipe->frameHeight() * h->pipe->frameWidth() * 4;
+  return librediffusion_img2img_turbo_frame_sized(
+      h, in_rgba, n, ehs, (size_t)librediffusion::Img2ImgTurboPipeline::kEhsElements, out_rgba, n);
+}
+
+librediffusion_error_t librediffusion_img2img_turbo_frame_dev(
+    librediffusion_img2img_turbo_handle h, const unsigned char* in_rgba,
+    const librediffusion_half_t* ehs_dev, unsigned char* out_rgba)
+{
+  if(!h || !h->pipe)
+    return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
+  const size_t n = (size_t)h->pipe->frameHeight() * h->pipe->frameWidth() * 4;
+  return librediffusion_img2img_turbo_frame_dev_sized(h, in_rgba, n, ehs_dev, out_rgba, n);
 }
 
 } // extern "C"

--- a/src/librediffusion_c.img2img_turbo.cpp
+++ b/src/librediffusion_c.img2img_turbo.cpp
@@ -8,25 +8,37 @@
 #include <memory>
 #include <stdexcept>
 
+#include "device_guard.hpp"
+
 using namespace librediffusion;
 
 struct librediffusion_img2img_turbo
 {
   std::unique_ptr<Img2ImgTurboPipeline> pipe;
+  int device{0};
 };
 
 extern "C" {
 
 librediffusion_img2img_turbo_handle librediffusion_img2img_turbo_create(
-    const char* unet_engine, const char* vae_encoder_engine, const char* vae_decoder_engine)
+    const char* unet_engine, const char* vae_encoder_engine, const char* vae_decoder_engine,
+    int device)
 {
+  const int dev = resolve_device(device);
+  if(dev < 0)
+  {
+    fprintf(stderr, "img2img_turbo_create: device %d is not a valid CUDA device ordinal\n", device);
+    return nullptr;
+  }
   try
   {
+    DeviceGuard guard{dev};
     Img2ImgTurboEngines p;
     p.unet = unet_engine ? unet_engine : "";
     p.vae_encoder = vae_encoder_engine ? vae_encoder_engine : "";
     p.vae_decoder = vae_decoder_engine ? vae_decoder_engine : "";
     auto h = std::make_unique<librediffusion_img2img_turbo>();
+    h->device = dev;
     h->pipe = std::make_unique<Img2ImgTurboPipeline>(p);  // may throw (engine load) -> h freed by RAII
     return h.release();
   }
@@ -39,6 +51,9 @@ librediffusion_img2img_turbo_handle librediffusion_img2img_turbo_create(
 
 void librediffusion_img2img_turbo_destroy(librediffusion_img2img_turbo_handle h)
 {
+  if(!h)
+    return;
+  DeviceGuard guard{h->device};
   delete h;
 }
 
@@ -48,6 +63,7 @@ librediffusion_error_t librediffusion_img2img_turbo_forward(
 {
   if(!h || !h->pipe)
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
+  DeviceGuard guard{h->device};
   if(!image_dev || !ehs_dev || !out_dev)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   try
@@ -108,6 +124,7 @@ librediffusion_error_t librediffusion_img2img_turbo_frame_sized(
 {
   if(!h || !h->pipe)
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
+  DeviceGuard guard{h->device};
   if(!in_rgba || !ehs || !out_rgba)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   if(librediffusion_error_t e = check_frame_sizes(h, in_bytes, ehs_elements, out_bytes);
@@ -131,6 +148,7 @@ librediffusion_error_t librediffusion_img2img_turbo_frame_dev_sized(
 {
   if(!h || !h->pipe)
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
+  DeviceGuard guard{h->device};
   if(!in_rgba || !ehs_dev || !out_rgba)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   // ehs is a DEVICE buffer here; its length is the engine's and is not the caller's to get wrong.
@@ -169,6 +187,7 @@ librediffusion_error_t librediffusion_img2img_turbo_frame_size(
 {
   if(!h || !h->pipe)
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
+  DeviceGuard guard{h->device};
   if(!out_width || !out_height)
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   *out_width = h->pipe->frameWidth();
@@ -183,6 +202,7 @@ librediffusion_error_t librediffusion_img2img_turbo_frame(
 {
   if(!h || !h->pipe)
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
+  DeviceGuard guard{h->device};
   const size_t n = (size_t)h->pipe->frameHeight() * h->pipe->frameWidth() * 4;
   return librediffusion_img2img_turbo_frame_sized(
       h, in_rgba, n, ehs, (size_t)h->pipe->ehsElements(), out_rgba, n);
@@ -194,6 +214,7 @@ librediffusion_error_t librediffusion_img2img_turbo_frame_dev(
 {
   if(!h || !h->pipe)
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
+  DeviceGuard guard{h->device};
   const size_t n = (size_t)h->pipe->frameHeight() * h->pipe->frameWidth() * 4;
   return librediffusion_img2img_turbo_frame_dev_sized(h, in_rgba, n, ehs_dev, out_rgba, n);
 }

--- a/src/librediffusion_c.img2img_turbo.cpp
+++ b/src/librediffusion_c.img2img_turbo.cpp
@@ -72,12 +72,12 @@ librediffusion_error_t librediffusion_img2img_turbo_forward(
 namespace
 {
 // The unsized _frame entry points copy H_*W_*4 bytes out of `in_rgba`, H_*W_*4 bytes INTO `out_rgba`
-// and 77*1024 floats out of `ehs` — none of which the caller ever declared.
+// and ehsElements() floats out of `ehs` — none of which the caller ever declared.
 librediffusion_error_t check_frame_sizes(
     librediffusion_img2img_turbo_handle h, size_t in_bytes, size_t ehs_elements, size_t out_bytes)
 {
   const size_t need = (size_t)h->pipe->frameHeight() * h->pipe->frameWidth() * 4;
-  const size_t need_ehs = (size_t)librediffusion::Img2ImgTurboPipeline::kEhsElements;
+  const size_t need_ehs = (size_t)h->pipe->ehsElements();
   // Capacity, not equality (same contract as rife's check_out_capacity): the entry points read
   // `need` bytes and write `need` bytes, so a caller who over-allocated is safe and must not be
   // refused. Only a SHORT buffer is a bug.
@@ -94,8 +94,7 @@ librediffusion_error_t check_frame_sizes(
   {
     fprintf(
         stderr,
-        "img2img_turbo: embedding too small — the model reads %zu floats [1,77,1024], caller "
-        "declared %zu\n",
+        "img2img_turbo: embedding too small — the model reads %zu floats, caller declared %zu\n",
         need_ehs, ehs_elements);
     return LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS;
   }
@@ -136,7 +135,7 @@ librediffusion_error_t librediffusion_img2img_turbo_frame_dev_sized(
     return LIBREDIFFUSION_ERROR_NULL_POINTER;
   // ehs is a DEVICE buffer here; its length is the engine's and is not the caller's to get wrong.
   if(librediffusion_error_t e = check_frame_sizes(
-         h, in_bytes, (size_t)librediffusion::Img2ImgTurboPipeline::kEhsElements, out_bytes);
+         h, in_bytes, (size_t)h->pipe->ehsElements(), out_bytes);
      e != LIBREDIFFUSION_SUCCESS)
     return e;
   try
@@ -162,7 +161,7 @@ int librediffusion_img2img_turbo_ehs_elements(librediffusion_img2img_turbo_handl
 {
   if(!h || !h->pipe)
     return 0;
-  return librediffusion::Img2ImgTurboPipeline::kEhsElements;
+  return h->pipe->ehsElements();
 }
 
 /* DEPRECATED: these declare no sizes, so the caller's buffers cannot be checked. Prefer _sized. */
@@ -174,7 +173,7 @@ librediffusion_error_t librediffusion_img2img_turbo_frame(
     return LIBREDIFFUSION_ERROR_NOT_INITIALIZED;
   const size_t n = (size_t)h->pipe->frameHeight() * h->pipe->frameWidth() * 4;
   return librediffusion_img2img_turbo_frame_sized(
-      h, in_rgba, n, ehs, (size_t)librediffusion::Img2ImgTurboPipeline::kEhsElements, out_rgba, n);
+      h, in_rgba, n, ehs, (size_t)h->pipe->ehsElements(), out_rgba, n);
 }
 
 librediffusion_error_t librediffusion_img2img_turbo_frame_dev(

--- a/src/librediffusion_c.img2img_turbo.cpp
+++ b/src/librediffusion_c.img2img_turbo.cpp
@@ -71,10 +71,8 @@ librediffusion_error_t librediffusion_img2img_turbo_forward(
 
 namespace
 {
-// L-03: the unsized _frame entry points copy H_*W_*4 bytes out of `in_rgba`, H_*W_*4 bytes INTO
-// `out_rgba` and 77*1024 floats out of `ehs` — none of which the caller ever declared. The _sized
-// variants below carry those declarations so the library can refuse a mismatch instead of walking
-// off the end of three host buffers.
+// The unsized _frame entry points copy H_*W_*4 bytes out of `in_rgba`, H_*W_*4 bytes INTO `out_rgba`
+// and 77*1024 floats out of `ehs` — none of which the caller ever declared.
 librediffusion_error_t check_frame_sizes(
     librediffusion_img2img_turbo_handle h, size_t in_bytes, size_t ehs_elements, size_t out_bytes)
 {
@@ -164,8 +162,7 @@ int librediffusion_img2img_turbo_ehs_elements(librediffusion_img2img_turbo_handl
   return librediffusion::Img2ImgTurboPipeline::kEhsElements;
 }
 
-/* DEPRECATED, kept for ABI compatibility: these declare no sizes, so the library CANNOT check that
- * the caller's buffers are big enough for what it copies. Prefer the _sized variants above. */
+/* DEPRECATED: these declare no sizes, so the caller's buffers cannot be checked. Prefer _sized. */
 librediffusion_error_t librediffusion_img2img_turbo_frame(
     librediffusion_img2img_turbo_handle h, const unsigned char* in_rgba, const float* ehs,
     unsigned char* out_rgba)

--- a/src/librediffusion_c.rife.cpp
+++ b/src/librediffusion_c.rife.cpp
@@ -59,12 +59,12 @@ void librediffusion_rife_set_interpolation_exp(librediffusion_rife_handle h, int
   h->exp = exp;
 }
 
-int librediffusion_rife_required_out_bytes(librediffusion_rife_handle h, int H, int W)
+size_t librediffusion_rife_required_out_bytes(librediffusion_rife_handle h, int H, int W)
 {
   if(!h || H <= 0 || W <= 0)
     return 0;
   const int eff_exp = h->enabled ? h->exp : 0;
-  return (1 << eff_exp) * H * W * 4;
+  return (size_t)(1u << eff_exp) * (size_t)H * (size_t)W * 4u;
 }
 
 int librediffusion_rife_get_interpolation_exp(librediffusion_rife_handle h)

--- a/src/librediffusion_c.rife.cpp
+++ b/src/librediffusion_c.rife.cpp
@@ -49,8 +49,25 @@ int librediffusion_rife_is_enabled(librediffusion_rife_handle h)
 
 void librediffusion_rife_set_interpolation_exp(librediffusion_rife_handle h, int exp)
 {
-  if(h)
-    h->exp = exp < 0 ? 0 : exp;
+  // Clamp BOTH ways. This used to clamp only from below, so any value was stored verbatim: a
+  // readback of 2147483647 was possible, and `for(i = 0; i < exp; ++i) total_out *= 2` is signed
+  // overflow (UB) from exp = 31 up. 2^LIBREDIFFUSION_RIFE_MAX_EXP frames per real frame is already
+  // far beyond anything a display pipeline can consume.
+  if(!h)
+    return;
+  if(exp < 0)
+    exp = 0;
+  else if(exp > LIBREDIFFUSION_RIFE_MAX_EXP)
+    exp = LIBREDIFFUSION_RIFE_MAX_EXP;
+  h->exp = exp;
+}
+
+int librediffusion_rife_required_out_bytes(librediffusion_rife_handle h, int H, int W)
+{
+  if(!h || H <= 0 || W <= 0)
+    return 0;
+  const int eff_exp = h->enabled ? h->exp : 0;
+  return (1 << eff_exp) * H * W * 4;
 }
 
 int librediffusion_rife_get_interpolation_exp(librediffusion_rife_handle h)
@@ -58,6 +75,63 @@ int librediffusion_rife_get_interpolation_exp(librediffusion_rife_handle h)
   return h ? h->exp : 0;
 }
 
+namespace
+{
+// L-05: interpolate() writes 2^exp * H*W*4 bytes into a caller buffer that carried no length, and
+// the frame count comes from state the caller set in a DIFFERENT call (set_interpolation_exp). Any
+// host that raises the interpolation factor without re-sizing its output buffer overflows it —
+// measured at 98 304 bytes past a 32 768-byte buffer for exp 1 -> 3. The _sized entry points let the
+// caller declare the capacity so the mismatch is an error code instead.
+librediffusion_error_t check_out_capacity(
+    librediffusion_rife_handle h, int H, int W, size_t out_capacity_bytes)
+{
+  const int eff_exp = h->enabled ? h->exp : 0;
+  const size_t need = (size_t)(1 << eff_exp) * (size_t)H * (size_t)W * 4u;
+  if(out_capacity_bytes < need)
+  {
+    fprintf(
+        stderr,
+        "rife_interpolate: out_frames capacity %zu bytes is too small — exp=%d at %dx%d needs %zu "
+        "bytes (%d frames)\n",
+        out_capacity_bytes, eff_exp, W, H, need, 1 << eff_exp);
+    return LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS;
+  }
+  return LIBREDIFFUSION_SUCCESS;
+}
+} // namespace
+
+librediffusion_error_t librediffusion_rife_interpolate_sized(
+    librediffusion_rife_handle h, const unsigned char* prev_rgba, const unsigned char* cur_rgba,
+    int H, int W, unsigned char* out_frames, size_t out_capacity_bytes, int* out_count)
+{
+  if(!h || !h->interp || !prev_rgba || !cur_rgba || !out_frames)
+    return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
+  if(H <= 0 || W <= 0)
+    return LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS;
+  if(librediffusion_error_t e = check_out_capacity(h, H, W, out_capacity_bytes);
+     e != LIBREDIFFUSION_SUCCESS)
+    return e;
+  return librediffusion_rife_interpolate(h, prev_rgba, cur_rgba, H, W, out_frames, out_count);
+}
+
+librediffusion_error_t librediffusion_rife_interpolate_gpu_sized(
+    librediffusion_rife_handle h, const unsigned char* prev_rgba_dev,
+    const unsigned char* cur_rgba_dev, int H, int W, unsigned char* out_frames_dev,
+    size_t out_capacity_bytes, int* out_count)
+{
+  if(!h || !h->interp || !prev_rgba_dev || !cur_rgba_dev || !out_frames_dev)
+    return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
+  if(H <= 0 || W <= 0)
+    return LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS;
+  if(librediffusion_error_t e = check_out_capacity(h, H, W, out_capacity_bytes);
+     e != LIBREDIFFUSION_SUCCESS)
+    return e;
+  return librediffusion_rife_interpolate_gpu(
+      h, prev_rgba_dev, cur_rgba_dev, H, W, out_frames_dev, out_count);
+}
+
+/* DEPRECATED, kept for ABI compatibility: no capacity is declared, so the library cannot check that
+ * out_frames is big enough for the 2^exp frames it is about to write. Prefer the _sized form. */
 librediffusion_error_t librediffusion_rife_interpolate(
     librediffusion_rife_handle h, const unsigned char* prev_rgba, const unsigned char* cur_rgba,
     int H, int W, unsigned char* out_frames, int* out_count)

--- a/src/librediffusion_c.rife.cpp
+++ b/src/librediffusion_c.rife.cpp
@@ -49,10 +49,7 @@ int librediffusion_rife_is_enabled(librediffusion_rife_handle h)
 
 void librediffusion_rife_set_interpolation_exp(librediffusion_rife_handle h, int exp)
 {
-  // Clamp BOTH ways. This used to clamp only from below, so any value was stored verbatim: a
-  // readback of 2147483647 was possible, and `for(i = 0; i < exp; ++i) total_out *= 2` is signed
-  // overflow (UB) from exp = 31 up. 2^LIBREDIFFUSION_RIFE_MAX_EXP frames per real frame is already
-  // far beyond anything a display pipeline can consume.
+  // Clamp both ways: `for(i = 0; i < exp; ++i) total_out *= 2` is signed overflow from exp = 31 up.
   if(!h)
     return;
   if(exp < 0)
@@ -77,11 +74,8 @@ int librediffusion_rife_get_interpolation_exp(librediffusion_rife_handle h)
 
 namespace
 {
-// L-05: interpolate() writes 2^exp * H*W*4 bytes into a caller buffer that carried no length, and
-// the frame count comes from state the caller set in a DIFFERENT call (set_interpolation_exp). Any
-// host that raises the interpolation factor without re-sizing its output buffer overflows it —
-// measured at 98 304 bytes past a 32 768-byte buffer for exp 1 -> 3. The _sized entry points let the
-// caller declare the capacity so the mismatch is an error code instead.
+// interpolate() writes 2^exp * H*W*4 bytes, and the frame count comes from state the caller set in a
+// DIFFERENT call (set_interpolation_exp), so the two drift apart trivially.
 librediffusion_error_t check_out_capacity(
     librediffusion_rife_handle h, int H, int W, size_t out_capacity_bytes)
 {
@@ -130,8 +124,7 @@ librediffusion_error_t librediffusion_rife_interpolate_gpu_sized(
       h, prev_rgba_dev, cur_rgba_dev, H, W, out_frames_dev, out_count);
 }
 
-/* DEPRECATED, kept for ABI compatibility: no capacity is declared, so the library cannot check that
- * out_frames is big enough for the 2^exp frames it is about to write. Prefer the _sized form. */
+/* DEPRECATED: no capacity is declared, so out_frames cannot be checked. Prefer the _sized form. */
 librediffusion_error_t librediffusion_rife_interpolate(
     librediffusion_rife_handle h, const unsigned char* prev_rgba, const unsigned char* cur_rgba,
     int H, int W, unsigned char* out_frames, int* out_count)

--- a/src/librediffusion_c.rife.cpp
+++ b/src/librediffusion_c.rife.cpp
@@ -1,5 +1,6 @@
 /** RIFE frame-interpolation C-API implementation (shared/model-agnostic). */
 #include "librediffusion.rife.hpp"
+#include "device_guard.hpp"
 #include "librediffusion_c.h"
 
 #include <cstdio>
@@ -12,15 +13,24 @@ struct librediffusion_rife
   std::unique_ptr<RifeInterpolator> interp;
   bool enabled{false};
   int exp{1};
+  int device{0};
 };
 
 extern "C" {
 
-librediffusion_rife_handle librediffusion_rife_create(const char* engine_path)
+librediffusion_rife_handle librediffusion_rife_create(const char* engine_path, int device)
 {
+  const int dev = resolve_device(device);
+  if(dev < 0)
+  {
+    fprintf(stderr, "rife_create: device %d is not a valid CUDA device ordinal\n", device);
+    return nullptr;
+  }
   try
   {
+    DeviceGuard guard{dev};
     auto* h = new librediffusion_rife;
+    h->device = dev;
     h->interp = std::make_unique<RifeInterpolator>(engine_path ? engine_path : "");
     return h;
   }
@@ -33,6 +43,9 @@ librediffusion_rife_handle librediffusion_rife_create(const char* engine_path)
 
 void librediffusion_rife_destroy(librediffusion_rife_handle h)
 {
+  if(!h)
+    return;
+  DeviceGuard guard{h->device};
   delete h;
 }
 
@@ -100,6 +113,7 @@ librediffusion_error_t librediffusion_rife_interpolate_sized(
 {
   if(!h || !h->interp || !prev_rgba || !cur_rgba || !out_frames)
     return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
+  DeviceGuard guard{h->device};
   if(H <= 0 || W <= 0)
     return LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS;
   if(librediffusion_error_t e = check_out_capacity(h, H, W, out_capacity_bytes);
@@ -115,6 +129,7 @@ librediffusion_error_t librediffusion_rife_interpolate_gpu_sized(
 {
   if(!h || !h->interp || !prev_rgba_dev || !cur_rgba_dev || !out_frames_dev)
     return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
+  DeviceGuard guard{h->device};
   if(H <= 0 || W <= 0)
     return LIBREDIFFUSION_ERROR_INVALID_DIMENSIONS;
   if(librediffusion_error_t e = check_out_capacity(h, H, W, out_capacity_bytes);
@@ -131,6 +146,7 @@ librediffusion_error_t librediffusion_rife_interpolate(
 {
   if(!h || !h->interp || !prev_rgba || !cur_rgba || !out_frames)
     return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
+  DeviceGuard guard{h->device};
   try
   {
     int eff_exp = h->enabled ? h->exp : 0;
@@ -152,6 +168,7 @@ librediffusion_error_t librediffusion_rife_interpolate_gpu(
 {
   if(!h || !h->interp || !prev_rgba_dev || !cur_rgba_dev || !out_frames_dev)
     return LIBREDIFFUSION_ERROR_INVALID_ARGUMENT;
+  DeviceGuard guard{h->device};
   try
   {
     int eff_exp = h->enabled ? h->exp : 0;

--- a/src/librediffusion_loader.hpp
+++ b/src/librediffusion_loader.hpp
@@ -204,6 +204,10 @@ public:
   LIBREDIFFUSION_SYMBOL_DEF(librediffusion, rife_get_interpolation_exp);
   LIBREDIFFUSION_SYMBOL_DEF(librediffusion, rife_interpolate);
   LIBREDIFFUSION_SYMBOL_DEF(librediffusion, rife_interpolate_gpu);
+  // Capacity-declaring forms (preferred; absent from older .so builds, hence OPT below).
+  LIBREDIFFUSION_SYMBOL_DEF(librediffusion, rife_interpolate_sized);
+  LIBREDIFFUSION_SYMBOL_DEF(librediffusion, rife_interpolate_gpu_sized);
+  LIBREDIFFUSION_SYMBOL_DEF(librediffusion, rife_required_out_bytes);
 
   /*=========================================================================*/
   /* img2img-turbo (pix2pix-turbo skip-VAE, github.com/GaParmar/img2img-turbo)*/
@@ -494,6 +498,9 @@ private:
     LIBREDIFFUSION_SYMBOL_INIT_OPT(librediffusion, rife_get_interpolation_exp);
     LIBREDIFFUSION_SYMBOL_INIT_OPT(librediffusion, rife_interpolate);
     LIBREDIFFUSION_SYMBOL_INIT_OPT(librediffusion, rife_interpolate_gpu);
+    LIBREDIFFUSION_SYMBOL_INIT_OPT(librediffusion, rife_interpolate_sized);
+    LIBREDIFFUSION_SYMBOL_INIT_OPT(librediffusion, rife_interpolate_gpu_sized);
+    LIBREDIFFUSION_SYMBOL_INIT_OPT(librediffusion, rife_required_out_bytes);
 
     /*=====================================================================*/
     /* img2img-turbo (pix2pix-turbo skip-VAE)                              */

--- a/src/librediffusion_loader.hpp
+++ b/src/librediffusion_loader.hpp
@@ -223,6 +223,7 @@ public:
   LIBREDIFFUSION_SYMBOL_DEF(librediffusion, img2img_turbo_frame_dev_sized);
   LIBREDIFFUSION_SYMBOL_DEF(librediffusion, img2img_turbo_frame_bytes);
   LIBREDIFFUSION_SYMBOL_DEF(librediffusion, img2img_turbo_ehs_elements);
+  LIBREDIFFUSION_SYMBOL_DEF(librediffusion, img2img_turbo_frame_size);
 
   /*=========================================================================*/
   /* Utility Functions                                                       */
@@ -515,6 +516,7 @@ private:
     LIBREDIFFUSION_SYMBOL_INIT_OPT(librediffusion, img2img_turbo_frame_dev_sized);
     LIBREDIFFUSION_SYMBOL_INIT_OPT(librediffusion, img2img_turbo_frame_bytes);
     LIBREDIFFUSION_SYMBOL_INIT_OPT(librediffusion, img2img_turbo_ehs_elements);
+    LIBREDIFFUSION_SYMBOL_INIT_OPT(librediffusion, img2img_turbo_frame_size);
 
     /*=====================================================================*/
     /* Utility Functions                                                   */

--- a/src/librediffusion_loader.hpp
+++ b/src/librediffusion_loader.hpp
@@ -214,6 +214,11 @@ public:
   LIBREDIFFUSION_SYMBOL_DEF(librediffusion, img2img_turbo_forward);
   LIBREDIFFUSION_SYMBOL_DEF(librediffusion, img2img_turbo_frame);
   LIBREDIFFUSION_SYMBOL_DEF(librediffusion, img2img_turbo_frame_dev);
+  // Size-declaring forms (preferred; absent from older .so builds, hence OPT below).
+  LIBREDIFFUSION_SYMBOL_DEF(librediffusion, img2img_turbo_frame_sized);
+  LIBREDIFFUSION_SYMBOL_DEF(librediffusion, img2img_turbo_frame_dev_sized);
+  LIBREDIFFUSION_SYMBOL_DEF(librediffusion, img2img_turbo_frame_bytes);
+  LIBREDIFFUSION_SYMBOL_DEF(librediffusion, img2img_turbo_ehs_elements);
 
   /*=========================================================================*/
   /* Utility Functions                                                       */
@@ -499,6 +504,10 @@ private:
     LIBREDIFFUSION_SYMBOL_INIT_OPT(librediffusion, img2img_turbo_forward);
     LIBREDIFFUSION_SYMBOL_INIT_OPT(librediffusion, img2img_turbo_frame);
     LIBREDIFFUSION_SYMBOL_INIT_OPT(librediffusion, img2img_turbo_frame_dev);
+    LIBREDIFFUSION_SYMBOL_INIT_OPT(librediffusion, img2img_turbo_frame_sized);
+    LIBREDIFFUSION_SYMBOL_INIT_OPT(librediffusion, img2img_turbo_frame_dev_sized);
+    LIBREDIFFUSION_SYMBOL_INIT_OPT(librediffusion, img2img_turbo_frame_bytes);
+    LIBREDIFFUSION_SYMBOL_INIT_OPT(librediffusion, img2img_turbo_ehs_elements);
 
     /*=====================================================================*/
     /* Utility Functions                                                   */

--- a/src/model_cache.hpp
+++ b/src/model_cache.hpp
@@ -443,6 +443,14 @@ public:
    */
   EnginePtr insert(const std::string& engine_path, EnginePtr engine)
   {
+    // NEVER store a null entry. A failed load used to be inserted verbatim under its path, which
+    // (a) poisoned that path against every later retry — get() found the stored null and reported
+    // "not loadable" forever, even after the file was restored — and (b) made the next eviction a
+    // null dereference in get_lru()/evict_if_needed(). A failed load must leave the cache exactly
+    // as it was so a retry can succeed.
+    if(!engine)
+      return nullptr;
+
     EnginePtr result = engine;
 
     bool inserted = cache_.emplace_or_cvisit(
@@ -491,6 +499,12 @@ public:
 
     // Load the engine
     EnginePtr engine = loader();
+
+    // A loader failure (missing file, unreadable, corrupt, does not fit in VRAM) is transient from
+    // the cache's point of view: report it to the caller, but do NOT record it. insert() refuses a
+    // null too; this check keeps the intent explicit at the call site.
+    if(!engine)
+      return nullptr;
 
     // Insert and return
     return insert(engine_path, std::move(engine));
@@ -555,6 +569,15 @@ private:
     bool found = false;
 
     cache_.visit_all([&](const auto& entry) {
+      // Defence in depth: insert()/get_or_load() no longer admit a null, but an entry that somehow
+      // is one must be treated as the OLDEST (evict it) rather than dereferenced.
+      if(!entry.second)
+      {
+        oldest_time = 0;
+        lru_key = entry.first;
+        found = true;
+        return;
+      }
       uint64_t access_time = entry.second->lastAccessTime();
       if(access_time < oldest_time)
       {

--- a/src/model_cache.hpp
+++ b/src/model_cache.hpp
@@ -443,11 +443,7 @@ public:
    */
   EnginePtr insert(const std::string& engine_path, EnginePtr engine)
   {
-    // NEVER store a null entry. A failed load used to be inserted verbatim under its path, which
-    // (a) poisoned that path against every later retry — get() found the stored null and reported
-    // "not loadable" forever, even after the file was restored — and (b) made the next eviction a
-    // null dereference in get_lru()/evict_if_needed(). A failed load must leave the cache exactly
-    // as it was so a retry can succeed.
+    // Never store a null: it would poison the path against retry and null-deref the next eviction.
     if(!engine)
       return nullptr;
 
@@ -500,9 +496,7 @@ public:
     // Load the engine
     EnginePtr engine = loader();
 
-    // A loader failure (missing file, unreadable, corrupt, does not fit in VRAM) is transient from
-    // the cache's point of view: report it to the caller, but do NOT record it. insert() refuses a
-    // null too; this check keeps the intent explicit at the call site.
+    // A loader failure is transient from the cache's point of view: report it, do not record it.
     if(!engine)
       return nullptr;
 
@@ -569,8 +563,7 @@ private:
     bool found = false;
 
     cache_.visit_all([&](const auto& entry) {
-      // Defence in depth: insert()/get_or_load() no longer admit a null, but an entry that somehow
-      // is one must be treated as the OLDEST (evict it) rather than dereferenced.
+      // A null entry (should be unreachable) is the oldest: evict it rather than dereference it.
       if(!entry.second)
       {
         oldest_time = 0;

--- a/src/model_cache.hpp
+++ b/src/model_cache.hpp
@@ -728,8 +728,13 @@ loadEngineFromFile(const std::string& engine_path, nvinfer1::ILogger& logger)
 inline std::shared_ptr<CachedTensorRTEngine>
 getCachedEngine(const std::string& engine_path)
 {
-  return GlobalEngineCache::instance().engines().get_or_load(
-      engine_path, [&engine_path]() {
+  // An ICudaEngine belongs to the device it was deserialized on, so the same file on two devices is
+  // two entries. Callers reach here inside a DeviceGuard, so the current device IS the owner's.
+  int device = 0;
+  cudaGetDevice(&device);
+  const std::string key = engine_path + '\x1f' + std::to_string(device);
+
+  return GlobalEngineCache::instance().engines().get_or_load(key, [&engine_path]() {
     return loadEngineFromFile(engine_path, GlobalEngineCache::instance().logger());
   });
 }

--- a/src/tensorrt_wrappers.cpp
+++ b/src/tensorrt_wrappers.cpp
@@ -2265,6 +2265,25 @@ void* checked_malloc(size_t bytes, const char* what)
         + std::to_string(bytes) + " bytes) failed: " + cudaGetErrorString(e));
   return p;
 }
+
+// checked_malloc throws, and so does anything below it that touches TensorRT. Every device
+// allocation made before that point has to be released or the caller leaks VRAM on a path it
+// cannot see; the wrappers' own destructors do not own these.
+struct DeviceFreeGuard
+{
+  void* p{};
+  ~DeviceFreeGuard()
+  {
+    if(p)
+      cudaFree(p);
+  }
+  void* release()
+  {
+    void* q = p;
+    p = nullptr;
+    return q;
+  }
+};
 } // namespace
 
 SDXLPromptEmbeddings computeClipEmbeddings_SDXL(
@@ -2286,45 +2305,44 @@ SDXLPromptEmbeddings computeClipEmbeddings_SDXL(
         "computeClipEmbeddings_SDXL: the second engine has no pooled output — it is not an "
         "SDXL CLIP2 (text_embeddings must be 2-D)");
 
-  SDXLPromptEmbeddings ret;
-
   // CLIP encoder 1: EOS padding (49407)
-  __half* d_embeds1 = clip.computeEmbeddings(prompt, clip_stream, 49407);
+  DeviceFreeGuard g_embeds1{clip.computeEmbeddings(prompt, clip_stream, 49407)};
 
   // CLIP encoder 2: pooled output, PAD padding (0)
   __half* d_pooled_row = nullptr;
-  __half* d_embeds2
-      = clip2.computeEmbeddingsWithPooled(prompt, clip_stream, 0, &d_pooled_row);
+  DeviceFreeGuard g_embeds2{
+      clip2.computeEmbeddingsWithPooled(prompt, clip_stream, 0, &d_pooled_row)};
+  DeviceFreeGuard g_pooled_row{d_pooled_row};
+
+  __half* const d_embeds1 = (__half*)g_embeds1.p;
+  __half* const d_embeds2 = (__half*)g_embeds2.p;
 
   // Both encoders run one prompt, so each source holds exactly ONE [77, h] row. Every batch element
   // shares that prompt: broadcast row 0 rather than indexing the source by b.
   const int hidden = h1 + h2;
-  ret.embeddings
-      = (__half*)checked_malloc((size_t)batch_size * 77 * hidden * sizeof(__half), "embeddings");
+  DeviceFreeGuard g_embeds{
+      checked_malloc((size_t)batch_size * 77 * hidden * sizeof(__half), "embeddings")};
+  __half* const d_out = (__half*)g_embeds.p;
 
   for(int b = 0; b < batch_size; ++b)
   {
     for(int s = 0; s < 77; ++s)
     {
       cudaMemcpy(
-          ret.embeddings + ((size_t)b * 77 + s) * hidden, d_embeds1 + (size_t)s * h1,
+          d_out + ((size_t)b * 77 + s) * hidden, d_embeds1 + (size_t)s * h1,
           h1 * sizeof(__half), cudaMemcpyDeviceToDevice);
       cudaMemcpy(
-          ret.embeddings + ((size_t)b * 77 + s) * hidden + h1, d_embeds2 + (size_t)s * h2,
+          d_out + ((size_t)b * 77 + s) * hidden + h1, d_embeds2 + (size_t)s * h2,
           h2 * sizeof(__half), cudaMemcpyDeviceToDevice);
     }
   }
 
-  ret.pooled_embeds
-      = (__half*)checked_malloc((size_t)batch_size * pooled_dim * sizeof(__half), "pooled_embeds");
+  DeviceFreeGuard g_pooled{
+      checked_malloc((size_t)batch_size * pooled_dim * sizeof(__half), "pooled_embeds")};
   for(int b = 0; b < batch_size; ++b)
     cudaMemcpy(
-        ret.pooled_embeds + (size_t)b * pooled_dim, d_pooled_row,
+        (__half*)g_pooled.p + (size_t)b * pooled_dim, d_pooled_row,
         pooled_dim * sizeof(__half), cudaMemcpyDeviceToDevice);
-
-  cudaFree(d_embeds1);
-  cudaFree(d_embeds2);
-  cudaFree(d_pooled_row);
 
   // Prepare time_ids: [original_height, original_width, crop_top, crop_left, target_height, target_width]
   std::vector<__half> time_ids_host(batch_size * 6);
@@ -2338,12 +2356,17 @@ SDXLPromptEmbeddings computeClipEmbeddings_SDXL(
     time_ids_host[i * 6 + 5] = __half(static_cast<float>(width));  // target_width
   }
 
-  ret.time_ids
-      = (__half*)checked_malloc((size_t)batch_size * 6 * sizeof(__half), "time_ids");
+  DeviceFreeGuard g_time_ids{
+      checked_malloc((size_t)batch_size * 6 * sizeof(__half), "time_ids")};
   cudaMemcpy(
-      ret.time_ids, time_ids_host.data(), batch_size * 6 * sizeof(__half),
+      g_time_ids.p, time_ids_host.data(), batch_size * 6 * sizeof(__half),
       cudaMemcpyHostToDevice);
 
+  // Nothing below here can throw: hand ownership to the caller.
+  SDXLPromptEmbeddings ret;
+  ret.embeddings = (__half*)g_embeds.release();
+  ret.pooled_embeds = (__half*)g_pooled.release();
+  ret.time_ids = (__half*)g_time_ids.release();
   return ret;
 }
 

--- a/src/tensorrt_wrappers.cpp
+++ b/src/tensorrt_wrappers.cpp
@@ -2123,42 +2123,115 @@ __half* CLIPWrapper::computeEmbeddingsWithPooled(
   }
 }
 
+namespace
+{
+// getTensorShape() on a name the engine does not declare logs an error and yields nbDims < 0;
+// look the name up first.
+nvinfer1::Dims io_shape(nvinfer1::ICudaEngine* eng, const char* name)
+{
+  nvinfer1::Dims none{};
+  none.nbDims = -1;
+  if(!eng)
+    return none;
+  for(int i = 0; i < eng->getNbIOTensors(); i++)
+  {
+    const char* n = eng->getIOTensorName(i);
+    if(n && std::string(n) == name)
+      return eng->getTensorShape(name);
+  }
+  return none;
+}
+} // namespace
+
+int CLIPWrapper::sequenceHiddenDim() const
+{
+  auto* eng = cached_engine_ ? cached_engine_->getEngine() : nullptr;
+  nvinfer1::Dims te = io_shape(eng, "text_embeddings");
+  if(te.nbDims == 3 && te.d[2] > 0)
+    return (int)te.d[2];
+  nvinfer1::Dims hs = io_shape(eng, "hidden_states");
+  return (hs.nbDims == 3 && hs.d[2] > 0) ? (int)hs.d[2] : 0;
+}
+
+int CLIPWrapper::pooledDim() const
+{
+  auto* eng = cached_engine_ ? cached_engine_->getEngine() : nullptr;
+  nvinfer1::Dims te = io_shape(eng, "text_embeddings");
+  return (te.nbDims == 2 && te.d[1] > 0) ? (int)te.d[1] : 0;
+}
+
+namespace
+{
+void* checked_malloc(size_t bytes, const char* what)
+{
+  void* p = nullptr;
+  cudaError_t e = cudaMalloc(&p, bytes);
+  if(e != cudaSuccess || !p)
+    throw std::runtime_error(
+        std::string("computeClipEmbeddings_SDXL: cudaMalloc(") + what + ", "
+        + std::to_string(bytes) + " bytes) failed: " + cudaGetErrorString(e));
+  return p;
+}
+} // namespace
+
 SDXLPromptEmbeddings computeClipEmbeddings_SDXL(
     CLIPWrapper& clip, CLIPWrapper& clip2, const std::string& prompt, int batch_size,
     int height, int width, cudaStream_t clip_stream)
 {
+  if(batch_size < 1)
+    throw std::invalid_argument("computeClipEmbeddings_SDXL: batch_size must be >= 1");
+
+  const int h1 = clip.sequenceHiddenDim();
+  const int h2 = clip2.sequenceHiddenDim();
+  const int pooled_dim = clip2.pooledDim();
+  if(h1 <= 0 || h2 <= 0)
+    throw std::runtime_error(
+        "computeClipEmbeddings_SDXL: CLIP engines declare no per-token embeddings ("
+        + std::to_string(h1) + " + " + std::to_string(h2) + ")");
+  if(pooled_dim <= 0)
+    throw std::runtime_error(
+        "computeClipEmbeddings_SDXL: the second engine has no pooled output — it is not an "
+        "SDXL CLIP2 (text_embeddings must be 2-D)");
+
   SDXLPromptEmbeddings ret;
 
-  // CLIP encoder 1: 768-dim with EOS padding (49407)
+  // CLIP encoder 1: EOS padding (49407)
   __half* d_embeds1 = clip.computeEmbeddings(prompt, clip_stream, 49407);
 
-  // CLIP encoder 2: 1280-dim with pooled output, PAD padding (0)
+  // CLIP encoder 2: pooled output, PAD padding (0)
+  __half* d_pooled_row = nullptr;
   __half* d_embeds2
-      = clip2.computeEmbeddingsWithPooled(prompt, clip_stream, 0, &ret.pooled_embeds);
+      = clip2.computeEmbeddingsWithPooled(prompt, clip_stream, 0, &d_pooled_row);
 
-  // Concatenate embeddings: [batch, 77, 768+1280] = [batch, 77, 2048]
-  size_t total_size = batch_size * 77 * 2048;
+  // Both encoders run one prompt, so each source holds exactly ONE [77, h] row. Every batch element
+  // shares that prompt: broadcast row 0 rather than indexing the source by b.
+  const int hidden = h1 + h2;
+  ret.embeddings
+      = (__half*)checked_malloc((size_t)batch_size * 77 * hidden * sizeof(__half), "embeddings");
 
-  cudaMalloc(&ret.embeddings, total_size * sizeof(__half));
-
-  // Copy embeddings sequentially for each batch element and sequence position
   for(int b = 0; b < batch_size; ++b)
   {
     for(int s = 0; s < 77; ++s)
     {
-      // Copy 768-dim from encoder 1
       cudaMemcpy(
-          ret.embeddings + (b * 77 + s) * 2048, d_embeds1 + (b * 77 + s) * 768,
-          768 * sizeof(__half), cudaMemcpyDeviceToDevice);
-      // Copy 1280-dim from encoder 2
+          ret.embeddings + ((size_t)b * 77 + s) * hidden, d_embeds1 + (size_t)s * h1,
+          h1 * sizeof(__half), cudaMemcpyDeviceToDevice);
       cudaMemcpy(
-          ret.embeddings + (b * 77 + s) * 2048 + 768, d_embeds2 + (b * 77 + s) * 1280,
-          1280 * sizeof(__half), cudaMemcpyDeviceToDevice);
+          ret.embeddings + ((size_t)b * 77 + s) * hidden + h1, d_embeds2 + (size_t)s * h2,
+          h2 * sizeof(__half), cudaMemcpyDeviceToDevice);
     }
   }
 
+  ret.pooled_embeds
+      = (__half*)checked_malloc((size_t)batch_size * pooled_dim * sizeof(__half), "pooled_embeds");
+  for(int b = 0; b < batch_size; ++b)
+    cudaMemcpy(
+        ret.pooled_embeds + (size_t)b * pooled_dim, d_pooled_row,
+        pooled_dim * sizeof(__half), cudaMemcpyDeviceToDevice);
+
   cudaFree(d_embeds1);
   cudaFree(d_embeds2);
+  cudaFree(d_pooled_row);
 
   // Prepare time_ids: [original_height, original_width, crop_top, crop_left, target_height, target_width]
   std::vector<__half> time_ids_host(batch_size * 6);
@@ -2172,7 +2245,8 @@ SDXLPromptEmbeddings computeClipEmbeddings_SDXL(
     time_ids_host[i * 6 + 5] = __half(static_cast<float>(width));  // target_width
   }
 
-  cudaMalloc(&ret.time_ids, batch_size * 6 * sizeof(__half));
+  ret.time_ids
+      = (__half*)checked_malloc((size_t)batch_size * 6 * sizeof(__half), "time_ids");
   cudaMemcpy(
       ret.time_ids, time_ids_host.data(), batch_size * 6 * sizeof(__half),
       cudaMemcpyHostToDevice);

--- a/src/tensorrt_wrappers.cpp
+++ b/src/tensorrt_wrappers.cpp
@@ -169,6 +169,10 @@ void UNetWrapper::loadEngine(const std::string& engine_path)
         // StreamV2V dynamic feature injection: [fi_strength, threshold] fp32 [2] bound at runtime.
         has_v2v_inject_params_ = true;
       }
+      else if(nm == "text_embeds" && eng->getTensorIOMode(tn) == nvinfer1::TensorIOMode::kINPUT)
+      {
+        has_sdxl_conditioning_ = true;
+      }
       else if(nm == "ipadapter_scale" && eng->getTensorIOMode(tn) == nvinfer1::TensorIOMode::kINPUT)
       {
         has_ipadapter_ = true;

--- a/src/tensorrt_wrappers.cpp
+++ b/src/tensorrt_wrappers.cpp
@@ -64,6 +64,23 @@ std::string dims_to_string(const std::vector<int>& d)
   return s + "]";
 }
 
+// getTensorShape() on a name the engine does not declare logs an error and yields nbDims < 0;
+// look the name up first.
+nvinfer1::Dims io_shape(const nvinfer1::ICudaEngine* eng, const char* name)
+{
+  nvinfer1::Dims none{};
+  none.nbDims = -1;
+  if(!eng)
+    return none;
+  for(int i = 0; i < eng->getNbIOTensors(); i++)
+  {
+    const char* n = eng->getIOTensorName(i);
+    if(n && std::string(n) == name)
+      return eng->getTensorShape(name);
+  }
+  return none;
+}
+
 // Empty if `want` is a shape the engine can actually be given for `tensor`: static dimensions must
 // match exactly, dynamic ones must fall inside optimization profile 0. An absent tensor, or one whose
 // rank we do not recognise, constrains nothing.
@@ -73,7 +90,7 @@ std::string shape_rejection(
 {
   if(!eng)
     return {};
-  const nvinfer1::Dims have = eng->getTensorShape(tensor);
+  const nvinfer1::Dims have = io_shape(eng, tensor);
   if(have.nbDims <= 0 || (size_t)have.nbDims != want.size())
     return {};
   if(eng->getTensorIOMode(tensor) != nvinfer1::TensorIOMode::kINPUT)
@@ -2215,26 +2232,6 @@ __half* CLIPWrapper::computeEmbeddingsWithPooled(
     return d_sequence_embeddings;
   }
 }
-
-namespace
-{
-// getTensorShape() on a name the engine does not declare logs an error and yields nbDims < 0;
-// look the name up first.
-nvinfer1::Dims io_shape(nvinfer1::ICudaEngine* eng, const char* name)
-{
-  nvinfer1::Dims none{};
-  none.nbDims = -1;
-  if(!eng)
-    return none;
-  for(int i = 0; i < eng->getNbIOTensors(); i++)
-  {
-    const char* n = eng->getIOTensorName(i);
-    if(n && std::string(n) == name)
-      return eng->getTensorShape(name);
-  }
-  return none;
-}
-} // namespace
 
 int CLIPWrapper::sequenceHiddenDim() const
 {

--- a/src/tensorrt_wrappers.cpp
+++ b/src/tensorrt_wrappers.cpp
@@ -52,6 +52,80 @@ void TensorRTLogger::log(Severity severity, const char* msg) noexcept
 }
 
 // ============================================================================
+// Optimization-profile checks (S-02)
+// ============================================================================
+namespace
+{
+std::string dims_to_string(const std::vector<int>& d)
+{
+  std::string s = "[";
+  for(size_t i = 0; i < d.size(); i++)
+    s += (i ? ", " : "") + std::to_string(d[i]);
+  return s + "]";
+}
+
+// Empty if `want` is a shape the engine can actually be given for `tensor`: static dimensions must
+// match exactly, dynamic ones must fall inside optimization profile 0. An absent tensor, or one whose
+// rank we do not recognise, constrains nothing.
+std::string shape_rejection(
+    const nvinfer1::ICudaEngine* eng, const char* role, const char* tensor,
+    const std::vector<int>& want)
+{
+  if(!eng)
+    return {};
+  const nvinfer1::Dims have = eng->getTensorShape(tensor);
+  if(have.nbDims <= 0 || (size_t)have.nbDims != want.size())
+    return {};
+  if(eng->getTensorIOMode(tensor) != nvinfer1::TensorIOMode::kINPUT)
+    return {};
+
+  bool dynamic = false;
+  for(int i = 0; i < have.nbDims; i++)
+    dynamic = dynamic || have.d[i] < 0;
+
+  nvinfer1::Dims lo{}, hi{};
+  if(dynamic)
+  {
+    lo = eng->getProfileShape(tensor, 0, nvinfer1::OptProfileSelector::kMIN);
+    hi = eng->getProfileShape(tensor, 0, nvinfer1::OptProfileSelector::kMAX);
+    if(lo.nbDims != have.nbDims || hi.nbDims != have.nbDims)
+      return {};
+  }
+
+  for(int i = 0; i < have.nbDims; i++)
+  {
+    if(have.d[i] >= 0)
+    {
+      if(want[i] != have.d[i])
+        return std::string(role) + " engine input '" + tensor + "' is a fixed "
+               + std::to_string(have.d[i]) + " in dimension " + std::to_string(i) + ", but "
+               + dims_to_string(want) + " asks for " + std::to_string(want[i]);
+    }
+    else if(want[i] < lo.d[i] || want[i] > hi.d[i])
+    {
+      return std::string(role) + " engine input '" + tensor + "' admits "
+             + std::to_string(lo.d[i]) + ".." + std::to_string(hi.d[i]) + " in dimension "
+             + std::to_string(i) + ", but " + dims_to_string(want) + " asks for "
+             + std::to_string(want[i]);
+    }
+  }
+  return {};
+}
+} // anonymous namespace
+
+std::string UNetWrapper::rejectGeometry(
+    int batch, int latent_height, int latent_width, int seq_len, int hidden_dim) const
+{
+  const nvinfer1::ICudaEngine* eng = cached_engine_ ? cached_engine_->getEngine() : nullptr;
+  std::string why = shape_rejection(
+      eng, "UNet", "sample", {batch, 4, latent_height, latent_width});
+  if(why.empty())
+    why = shape_rejection(
+        eng, "UNet", "encoder_hidden_states", {batch, seq_len, hidden_dim});
+  return why;
+}
+
+// ============================================================================
 // UNetWrapper Implementation
 // ============================================================================
 
@@ -1667,6 +1741,13 @@ void VAEEncoderWrapper::encode(
   }
 }
 
+std::string VAEEncoderWrapper::rejectGeometry(int batch, int height, int width) const
+{
+  return shape_rejection(
+      cached_engine_ ? cached_engine_->getEngine() : nullptr, "VAE encoder", "images",
+      {batch, 3, height, width});
+}
+
 // ============================================================================
 // VAEDecoderWrapper Implementation
 // ============================================================================
@@ -1755,6 +1836,14 @@ void VAEDecoderWrapper::decode(
   {
     throw std::runtime_error("Failed to enqueue inference");
   }
+}
+
+std::string VAEDecoderWrapper::rejectGeometry(
+    int batch, int latent_height, int latent_width) const
+{
+  return shape_rejection(
+      cached_engine_ ? cached_engine_->getEngine() : nullptr, "VAE decoder", "latent",
+      {batch, 4, latent_height, latent_width});
 }
 
 // ============================================================================

--- a/src/tensorrt_wrappers.cpp
+++ b/src/tensorrt_wrappers.cpp
@@ -52,7 +52,7 @@ void TensorRTLogger::log(Severity severity, const char* msg) noexcept
 }
 
 // ============================================================================
-// Optimization-profile checks (S-02)
+// Optimization-profile checks
 // ============================================================================
 namespace
 {

--- a/src/tensorrt_wrappers.hpp
+++ b/src/tensorrt_wrappers.hpp
@@ -570,6 +570,11 @@ public:
       const std::string& prompt, cudaStream_t stream, int pad_token,
       __half** pooled_output);
 
+  /// Last dim of the per-token embeddings this engine emits, or 0 if it declares none.
+  int sequenceHiddenDim() const;
+  /// Last dim of the pooled embedding (CLIP2 only), or 0 if this engine has no pooled output.
+  int pooledDim() const;
+
 private:
   std::shared_ptr<CachedTensorRTEngine> cached_engine_;  // Shared cached engine
   std::unique_ptr<nvinfer1::IExecutionContext> context_; // Per-wrapper context

--- a/src/tensorrt_wrappers.hpp
+++ b/src/tensorrt_wrappers.hpp
@@ -127,6 +127,9 @@ public:
   /// True if the loaded engine declares the input_control_* residual inputs (control-aware UNet).
   bool hasControlInputs() const { return has_control_inputs_; }
 
+  /// True if the engine declares the SDXL added conditioning inputs (text_embeds + time_ids).
+  bool hasSdxlConditioning() const { return has_sdxl_conditioning_; }
+
   /// True if the loaded engine is an IP-Adapter variant (declares the `ipadapter_scale` input).
   bool hasIpAdapter() const { return has_ipadapter_; }
   /// Length of the ipadapter_scale vector (= num cross-attn IP layers), detected at load (0 if none).
@@ -192,6 +195,8 @@ public:
 
   /// True if the loaded engine declares the kvo_cache_in_* inputs (live StreamV2V UNet).
   bool hasV2VKvo() const { return has_v2v_kvo_; }
+  /// True if the engine declares the legacy attention_* StreamV2V outputs.
+  bool hasV2VOutputs() const { return has_v2v_outputs_; }
   /// True if the engine banks attention OUTPUTS (3-component [K,V,O]) — i.e. feature injection is baked.
   bool hasV2VInject() const { return kvo_components_ >= 3; }
   /// Clear the rolling K/V bank (zeros) so the next frame starts an empty temporal context.
@@ -292,6 +297,7 @@ private:
 
   // IP-Adapter: engine declares an `ipadapter_scale` fp32 vector input (+ a longer ehs seq). The IP
   // attention is baked into the engine; we only bind the per-layer scale vector here.
+  bool has_sdxl_conditioning_ = false;  // engine declares text_embeds + time_ids
   bool has_ipadapter_ = false;
   int num_ip_layers_ = 0;
   std::unique_ptr<CUDATensor<float>> ipadapter_scale_buffer_;

--- a/src/tensorrt_wrappers.hpp
+++ b/src/tensorrt_wrappers.hpp
@@ -193,6 +193,10 @@ public:
   /// runtime-adjustable rather than baked).
   bool hasV2VDynamicInject() const { return has_v2v_inject_params_; }
 
+  /// Empty if the engine's optimization profile admits this geometry, otherwise why not.
+  std::string rejectGeometry(
+      int batch, int latent_height, int latent_width, int seq_len, int hidden_dim) const;
+
   /// True if the loaded engine declares the kvo_cache_in_* inputs (live StreamV2V UNet).
   bool hasV2VKvo() const { return has_v2v_kvo_; }
   /// True if the engine declares the legacy attention_* StreamV2V outputs.
@@ -441,6 +445,9 @@ public:
       const float* images, __half* latent, int batch, int height, int width,
       cudaStream_t stream);
 
+  /// Empty if the engine's optimization profile admits this geometry, otherwise why not.
+  std::string rejectGeometry(int batch, int height, int width) const;
+
 private:
   std::shared_ptr<CachedTensorRTEngine> cached_engine_;  // Shared cached engine
   std::unique_ptr<nvinfer1::IExecutionContext> context_; // Per-wrapper context
@@ -494,6 +501,9 @@ public:
   void decode(
       const __half* latent, __half* images, int batch, int height, int width,
       cudaStream_t stream);
+
+  /// Empty if the engine's optimization profile admits this geometry, otherwise why not.
+  std::string rejectGeometry(int batch, int latent_height, int latent_width) const;
 
 private:
   std::shared_ptr<CachedTensorRTEngine> cached_engine_;  // Shared cached engine


### PR DESCRIPTION
Fixes every library defect confirmed by the new `lrd-hardening` suite: each was **empirically reproduced** (signal, or measured corruption) before being fixed, and each fix is verified by the test that previously failed.

One commit per fix, in dependency order.

| Commit | Defect | Was |
|---|---|---|
| `03ef6bd` | L-01 null engine in the LRU cache | **SIGSEGV** on any eviction after a failed load — including simply loading under a cap of 2. The path also stayed permanently unloadable after the file was restored. |
| `855a06c` | L-02 inference before prepare | **SIGSEGV**, all four orders |
| `e0e8c1c` | L-11 handle validation / create out-param / stream drain | double-destroy → **SIGABRT** (config) and **SIGSEGV** (pipeline); a destroyed handle answered queries with garbage (width `1771711538`, `synchronize()==SUCCESS`) |
| `55592e6` | L-06 text dims vs config | `prepare_embeds(…,77,768)` on a 1024-wide pipeline returned SUCCESS; OOB surfaced later as an opaque CUB error *after* partially writing the output |
| `f51a05e` | L-16 schedule vs `denoising_steps` | `denoising_steps=2` with a 1-entry schedule returned SUCCESS while indexing past the end |
| `0af4fa3` | L-09 `cache_interval` / `cache_maxframes` | `interval=0` → **SIGFPE**; `maxframes=-1` → unbounded VRAM growth |
| `bdf1b1f` | L-14 non-finite scheduler coefficients | NaN/inf/alpha=0 accepted; frames returned SUCCESS |
| `97cec38` | L-08 `rgba_resize` was dead code | an unconditional `return;` meant it had **never resized**: a 256×256 input on a 512 bundle produced a **pure black frame, byte-identical for two different inputs** |
| `fd7c92e` | L-03 img2img-turbo buffer sizes | **SIGSEGV** on a guard page in all three directions |
| `229327d` | L-05 RIFE output capacity | measured **98 304 bytes written past a 32 768-byte buffer** |
| `d403c10` | L-13 `config_create` initialised CUDA | created a primary context on the default device before `config_set_device` was read, and broke a later `fork()` |
| `7b824f3` | L-15 silent feature drop | a CN/IP the bundle can't honour was silently ignored; frames statistically identical to the plain model |
| `6cb109c` | L-07 geometry validation | `config_set_dimensions` accepted 185600² and 513×511 |
| `f230777` | L-07 bonus: checked `cudaMalloc` | 60 unchecked call sites; `CUDATensor::data_` wasn't even in the member-init list |

## Verification
Full suite **31/31 green** (was 20 expected failures). Behaviour regressions re-checked verbatim:
- `lrd_sched_change_test` → `MAD(B_live, B_ref) = 0.00`, **OK**
- `lrd_addnoise_test` → `MAD(on,off) = 12.89`, **OK**
- `graph_cn_ip_test cn` → tracks at **99.0 dB**, not baked (16.4 dB), **CORRECT**, graph speedup retained (1.07×)
- L-08: at native resolution, frames are byte-identical (same FNV hashes) before and after re-enabling the resize.

## Three things to read before merging
1. **L-03/L-05 are additive, not an ABI break.** New `*_sized` entry points + capacity helpers (`img2img_turbo_frame_bytes`, `rife_required_out_bytes`), registered as optional symbols; the old 4-arg forms are marked deprecated. **They still overflow if a caller lies about the buffer size — they cannot do better, since they are never told it.** The score node should migrate to `_sized`; the loader plumbing is in place.
2. **`-ffast-math` makes `std::isfinite()` a no-op here.** The L-14 guard inspects IEEE-754 bits instead. Relevant to any future validation code in this repo.
3. **L-16 rejects rather than truncating**, and `config_set_dimensions` now enforces `latent == image/8`. Both are intended behaviour changes; every in-tree caller already complies.

Tests live in a separate local `lrd-hardening` repo (they need the engine bundles on this workstation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)